### PR TITLE
allow workers and reducers to close custom context

### DIFF
--- a/dranspose/reducer.py
+++ b/dranspose/reducer.py
@@ -184,6 +184,19 @@ class Reducer(DistributedService):
         )
 
     async def close(self) -> None:
+        if self.reducer:
+            if hasattr(self.reducer, "close"):
+                try:
+                    loop = asyncio.get_event_loop()
+                    await loop.run_in_executor(
+                        None, self.reducer.close, self.custom_context
+                    )
+                except Exception as e:
+                    self._logger.error(
+                        "custom reducer failed to close: %s\n%s",
+                        e.__repr__(),
+                        traceback.format_exc(),
+                    )
         await cancel_and_wait(self.timer_task)
         await cancel_and_wait(self.work_task)
         await cancel_and_wait(self.metrics_task)

--- a/dranspose/worker.py
+++ b/dranspose/worker.py
@@ -510,6 +510,19 @@ class Worker(DistributedService):
             await asyncio.sleep(2)
 
     async def close(self) -> None:
+        if self.worker:
+            if hasattr(self.worker, "close"):
+                try:
+                    loop = asyncio.get_event_loop()
+                    await loop.run_in_executor(
+                        None, self.worker.close, self.custom_context
+                    )
+                except Exception as e:
+                    self._logger.error(
+                        "custom worker failed to close: %s\n%s",
+                        e.__repr__(),
+                        traceback.format_exc(),
+                    )
         await cancel_and_wait(self.manage_ingester_task)
         await cancel_and_wait(self.manage_receiver_task)
         await cancel_and_wait(self.metrics_task)

--- a/examples/repub/worker.py
+++ b/examples/repub/worker.py
@@ -28,3 +28,9 @@ class RepubWorker:
         self.buffer[event.event_number] = event
 
         self.sock.send_multipart(event.streams["eiger"].frames)
+
+    def close(self, context):
+        if "socket" in context:
+            context["socket"].close()
+        if "context" in context:
+            context["context"].destroy(linger=0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -479,19 +479,7 @@ async def stream_pkls() -> Callable[
         end: Optional[int] = None,
     ) -> None:
         socket: zmq.Socket[Any] = ctx.socket(typ)
-        try:
-            socket.bind(f"tcp://*:{port}")
-        except zmq.ZMQError as e:
-            if e.errno == 98:
-                logging.warning(
-                    "binding not possible %d: %s, retry in 2 seconds",
-                    e.errno,
-                    e.__repr__(),
-                )
-                await asyncio.sleep(2)
-                socket.bind(f"tcp://*:{port}")
-            else:
-                raise e
+        socket.bind(f"tcp://*:{port}")
         if begin is None and end is None:
             for _ in range(3):
                 await socket.send_multipart([b"emptyness"])

--- a/tests/test_close_context.py
+++ b/tests/test_close_context.py
@@ -1,0 +1,34 @@
+import asyncio
+import logging
+
+from dranspose.helpers.utils import cancel_and_wait
+from dranspose.protocol import (
+    WorkerName,
+)
+
+import pytest
+
+from dranspose.worker import Worker, WorkerSettings
+from tests.utils import wait_for_controller
+
+
+@pytest.mark.asyncio
+async def test_context(
+    controller: None,
+) -> None:
+    worker = Worker(
+        settings=WorkerSettings(
+            worker_name=WorkerName("w5555"),
+            worker_class="examples.repub.worker:RepubWorker",
+        ),
+    )
+    worker_task = asyncio.create_task(worker.run())
+
+    await wait_for_controller(workers={WorkerName("w5555")})
+
+    logging.info("custom context is %s", worker.custom_context)
+    assert worker.custom_context["context"].closed is False
+    await worker.close()
+    await cancel_and_wait(worker_task)
+    logging.info("custom context is %s", worker.custom_context)
+    assert worker.custom_context["context"].closed is True


### PR DESCRIPTION
If the worker or reducer payload stores an object in the custom context, it can now use close() to clean up the context.
This is relevant for the workers which store a ZMQ context in the context, otherwise the sockets of them linger and cause other tests to crash.