### PR TITLE
Test fixes

### DIFF
--- a/.github/workflows/buildimage.yml
+++ b/.github/workflows/buildimage.yml
@@ -48,6 +48,20 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          load: true
+
+      - name: Test
+        run: |
+          docker run --rm --env REDIS_URL="redis://localhost:6379/0" ${{ steps.meta.outputs.tags }} -- pytest tests/* --rust --log-cli-level=INFO
+
+    services:
+      # Label used to access the service container
+      redis:
+        # Docker Hub image
+        image: redis
+        ports:
+          # Opens tcp port 6379 on the host and service container
+          - 6379:6379
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
       #- name: Generate artifact attestation

--- a/.github/workflows/buildimage.yml
+++ b/.github/workflows/buildimage.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Test
         run: |
-          docker run --rm --env REDIS_URL="redis://localhost:6379/0" ${{ steps.meta.outputs.tags }} -- pytest tests/* --rust --log-cli-level=INFO
+          docker run --rm --network host --env REDIS_URL="redis://localhost:6379/0" ${{ steps.meta.outputs.tags }} sh -c "python -m pip install '.[tests]' && pytest tests/* --rust --log-cli-level=INFO"
 
     services:
       # Label used to access the service container

--- a/dranspose/controller.py
+++ b/dranspose/controller.py
@@ -326,6 +326,7 @@ class Controller:
         cupd = ControllerUpdate(
             mapping_uuid=self.mapping.uuid,
             parameters_version={n: p.uuid for n, p in self.parameters.items()},
+            target_parameters_hash=self.parameters_hash,
         )
         logger.debug("send update %s", cupd)
         await self.redis.xadd(

--- a/dranspose/controller.py
+++ b/dranspose/controller.py
@@ -626,18 +626,26 @@ class Controller:
         await cancel_and_wait(self.default_task)
         await cancel_and_wait(self.consistent_task)
         await self.redis.delete(RedisKeys.updates())
+        logger.info("deleted updates redis stream")
         queues = await self.redis.keys(RedisKeys.ready("*"))
         if len(queues) > 0:
             await self.redis.delete(*queues)
+            logger.info("deleted ready queues %s", queues)
         assigned = await self.redis.keys(RedisKeys.assigned("*"))
         if len(assigned) > 0:
             await self.redis.delete(*assigned)
         params = await self.redis.keys(RedisKeys.parameters("*", "*"))
         if len(params) > 0:
             await self.redis.delete(*params)
+            logger.info("deleted parameters %s", params)
+        param_descr = await self.redis.keys(RedisKeys.parameter_description("*"))
+        if len(param_descr) > 0:
+            await self.redis.delete(*param_descr)
+            logger.info("deleted parameter descriptions %s", params)
         await cancel_and_wait(self.lock_task)
         await self.redis.delete(RedisKeys.lock())
         await self.redis.aclose()
+        logger.info("controller closed")
 
 
 ctrl: Controller

--- a/dranspose/controller.py
+++ b/dranspose/controller.py
@@ -8,7 +8,7 @@ import os.path
 from asyncio import Task
 from collections import defaultdict
 from types import UnionType
-from typing import Any, AsyncGenerator, Optional, Annotated, Literal
+from typing import Any, AsyncGenerator, Optional, Annotated, Literal, AsyncIterator
 
 import logging
 import time
@@ -807,7 +807,7 @@ async def stop() -> None:
     ctrl.external_stop = True
 
 
-async def log_streamer():
+async def log_streamer() -> AsyncIterator[str]:
     latest = await ctrl.redis.xrevrange("dranspose_logs", count=1)
     last = 0
     if len(latest) > 0:
@@ -823,7 +823,7 @@ async def log_streamer():
 
 
 @app.get("/api/v1/log_stream")
-async def get_log_stream():
+async def get_log_stream() -> StreamingResponse:
     return StreamingResponse(log_streamer())
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,11 +220,16 @@ async def create_ingester(
 
     async def _make_ingester(inst: Ingester, subprocess: bool = False) -> Ingester:
         if request.config.getoption("rust"):
-            logging.warning("replace ingester with rust")
+            logging.info("replace ingester with rust")
             if isinstance(inst, ZmqPullSingleIngester):
-                logging.warning("ues settings %s", inst._streaming_single_settings)
+                logging.info("use settings %s", inst._streaming_single_settings)
+                if os.path.exists("/bin/fast_ingester"):
+                    binary_path = "/bin/fast_ingester"
+                else:
+                    binary_path = "./perf/target/debug/fast_ingester"
+                    logging.warning("using debug ingester")
                 proc = await asyncio.create_subprocess_exec(
-                    "./perf/target/debug/fast_ingester",
+                    binary_path,
                     "--stream",
                     inst._streaming_single_settings.ingester_streams[0],
                     "--upstream-url",

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -6,6 +6,7 @@ from typing import Awaitable, Callable, Any, Coroutine, Optional
 import aiohttp
 
 import pytest
+from _pytest.fixtures import FixtureRequest
 import zmq.asyncio
 import zmq
 from pydantic_core import Url
@@ -32,7 +33,7 @@ from tests.utils import wait_for_controller, wait_for_finish
 
 @pytest.mark.asyncio
 async def test_simple(
-    request,
+    request: FixtureRequest,
     controller: None,
     reducer: Callable[[Optional[str]], Awaitable[None]],
     create_worker: Callable[[WorkerName], Awaitable[Worker]],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,3 +76,4 @@ def test_replay_no_redis() -> None:
     text = (b"".join(p.communicate())).decode()
     logging.info("got out+err: %s", text)
     assert "usage: dranspose" in text
+    p.wait()

--- a/tests/test_concurrent_restart_controller.py
+++ b/tests/test_concurrent_restart_controller.py
@@ -117,4 +117,10 @@ async def test_restart() -> None:
 
     instance2.stop()
 
+    instance2.join()
+
+    keys = await r.keys("*:*")
+
     await r.aclose()
+
+    assert keys == []

--- a/tests/test_log_stream.py
+++ b/tests/test_log_stream.py
@@ -2,6 +2,8 @@ import asyncio
 import json
 import logging
 import subprocess
+from typing import Any
+
 import aiohttp
 
 import pytest
@@ -9,7 +11,7 @@ import pytest
 from dranspose.helpers.utils import cancel_and_wait
 
 
-async def sink(msgs):
+async def sink(msgs: list[Any]) -> None:
     async with aiohttp.ClientSession(raise_for_status=True) as session:
         async with session.get("http://localhost:5000/api/v1/log_stream") as r:
             async for line in r.content:

--- a/tests/test_log_stream.py
+++ b/tests/test_log_stream.py
@@ -26,7 +26,7 @@ async def test_stream() -> None:
 
     logging.info("started process")
     await asyncio.sleep(4)
-    msgs = []
+    msgs: list[Any] = []
     s = asyncio.create_task(sink(msgs))
     logging.info("created sink")
     await asyncio.sleep(1)


### PR DESCRIPTION
This fixes various test issues also related to issue #16 .
- On shutdown the controller now deletes parameter descriptions. The problem occurred on a controller restart, where it would initialise default parameters from descriptions of an old worker/reducer.
- The rust ingester does not recalculate the parameter hash and the controller did not always send the target hash.
- The name of the rust ingesters is different.
- To continually test the rust ingester, the CI uses the freshly built image and runs the rust test inside, using the release binary. 