### PR TITLE
Process to thread

### DIFF
--- a/dranspose/controller.py
+++ b/dranspose/controller.py
@@ -648,252 +648,245 @@ class Controller:
         logger.info("controller closed")
 
 
-ctrl: Controller
-
-
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Load the ML model
-    global ctrl
-    ctrl = Controller()
+    app.state.ctrl = Controller()
     # run_task = asyncio.create_task(ctrl.run())
-    await ctrl.run()
+    await app.state.ctrl.run()
     # run_task.add_done_callback(done_callback)
     yield
     # await cancel_and_wait(run_task)
-    await ctrl.close()
+    await app.state.ctrl.close()
     # Clean up the ML models and release the resources
 
 
-app = FastAPI(lifespan=lifespan)
+def routes_legacy(app):
+    @app.post("/api/v1/mapping")
+    async def set_mapping(
+        request: Request,
+        mapping: dict[StreamName, list[Optional[list[VirtualWorker]]]],
+        all_wrap: bool = True,
+    ) -> UUID4 | str:
+        ctrl = request.app.state.ctrl
+        config = await ctrl.get_configs()
+        if set(mapping.keys()) - set(config.get_streams()) != set():
+            logger.warning(
+                "bad request streams %s not available",
+                set(mapping.keys()) - set(config.get_streams()),
+            )
+            raise HTTPException(
+                status_code=400,
+                detail=f"streams {set(mapping.keys()) - set(config.get_streams())} not available",
+            )
+        m = MappingSequence(
+            parts={MappingName("main"): mapping},
+            sequence=[MappingName("main")],
+            add_start_end=all_wrap,
+        )
+        if len(config.workers) < m.min_workers():
+            logger.warning(
+                "only %d workers available, but %d required",
+                len(config.workers),
+                m.min_workers(),
+            )
+            raise HTTPException(
+                status_code=400,
+                detail=f"only {len(config.workers)} workers available, but {m.min_workers()} required",
+            )
+        await ctrl.set_mapping(m)
+        return m.uuid
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-)
+    @app.get("/api/v1/logs")
+    async def get_logs(request: Request, level: str = "INFO") -> Any:
+        data = await request.app.state.ctrl.redis.xrange("dranspose_logs", "-", "+")
+        logs = []
+        # TODO: once python 3.10 support is dropped, use
+        # levels = logging.getLevelNamesMapping()
+        levels = {
+            level: logging.__getattribute__(level)
+            for level in dir(logging)
+            if level.isupper() and isinstance(logging.__getattribute__(level), int)
+        }
+        minlevel = levels.get(level.upper(), logging.INFO)
+        for entry in data:
+            msglevel = levels[entry[1].get("levelname", "DEBUG")]
+            if msglevel >= minlevel:
+                logs.append(entry[1])
+        return logs
+
+    @app.post("/api/v1/sardana_hook")
+    async def set_sardana_hook(
+        request: Request, info: dict[Literal["streams"] | Literal["scan"], Any]
+    ) -> UUID4 | str:
+        ctrl = request.app.state.ctrl
+        config = await ctrl.get_configs()
+        print(info)
+        if "scan" not in info:
+            return "no scan info"
+        if "nb_points" not in info["scan"]:
+            return "no nb_points in scan"
+        if "streams" not in info:
+            return "streams required"
+        for st in set(config.get_streams()).intersection(set(info["streams"])):
+            print("use stream", st)
+        logger.debug("create new mapping")
+        m = Map.from_uniform(
+            set(config.get_streams()).intersection(set(info["streams"])),
+            info["scan"]["nb_points"],
+        )
+        s = MappingSequence(
+            parts={MappingName("sardana"): m.mapping},
+            sequence=[MappingName("sardana")],
+            add_start_end=True,
+        )
+        logger.debug("set mapping")
+        await ctrl.set_mapping(s)
+        return s.uuid
 
 
-@app.get("/")
-async def read_index() -> FileResponse:
-    return FileResponse(
-        os.path.join(os.path.dirname(__file__), "frontend", "index.html")
+def routes_status(app):
+    @app.get("/api/v1/config")
+    async def get_configs(request: Request) -> EnsembleState:
+        return await request.app.state.ctrl.get_configs()
+
+    @app.get("/api/v1/status")
+    async def get_status(request: Request) -> dict[str, Any]:
+        ctrl = request.app.state.ctrl
+        return {
+            "work_completed": ctrl.completed,
+            "last_assigned": ctrl.mapping.complete_events,
+            "assignment": [am.assignments for am in ctrl.mapping.active_maps],
+            "completed_events": ctrl.completed_events,
+            "finished": await ctrl.completed_finish(),
+            "processing_times": ctrl.worker_timing,
+        }
+
+    @app.get("/api/v1/load")
+    async def get_load(
+        request: Request,
+        intervals: Annotated[list[int] | None, Query()] = None,
+        scan: bool = True,
+    ) -> SystemLoadType:
+        if intervals is None:
+            intervals = [1, 10]
+        return await request.app.state.ctrl.get_load(intervals, scan)
+
+    @app.get("/api/v1/progress")
+    async def get_progress(request: Request) -> dict[str, Any]:
+        ctrl = request.app.state.ctrl
+        return {
+            "last_assigned": ctrl.mapping.complete_events,
+            "completed_events": len(ctrl.completed_events),
+            "total_events": ctrl.mapping.len(),
+            "finished": await ctrl.completed_finish(),
+        }
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(lifespan=lifespan)
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
     )
 
-
-@app.get("/api/v1/config")
-async def get_configs() -> EnsembleState:
-    global ctrl
-    return await ctrl.get_configs()
-
-
-@app.get("/api/v1/status")
-async def get_status() -> dict[str, Any]:
-    global ctrl
-    return {
-        "work_completed": ctrl.completed,
-        "last_assigned": ctrl.mapping.complete_events,
-        "assignment": [am.assignments for am in ctrl.mapping.active_maps],
-        "completed_events": ctrl.completed_events,
-        "finished": await ctrl.completed_finish(),
-        "processing_times": ctrl.worker_timing,
-    }
-
-
-@app.get("/api/v1/load")
-async def get_load(
-    intervals: Annotated[list[int] | None, Query()] = None, scan: bool = True
-) -> SystemLoadType:
-    global ctrl
-    if intervals is None:
-        intervals = [1, 10]
-    return await ctrl.get_load(intervals, scan)
-
-
-@app.get("/api/v1/progress")
-async def get_progress() -> dict[str, Any]:
-    global ctrl
-    return {
-        "last_assigned": ctrl.mapping.complete_events,
-        "completed_events": len(ctrl.completed_events),
-        "total_events": ctrl.mapping.len(),
-        "finished": await ctrl.completed_finish(),
-    }
-
-
-@app.post("/api/v1/mapping")
-async def set_mapping(
-    mapping: dict[StreamName, list[Optional[list[VirtualWorker]]]],
-    all_wrap: bool = True,
-) -> UUID4 | str:
-    global ctrl
-    config = await ctrl.get_configs()
-    if set(mapping.keys()) - set(config.get_streams()) != set():
-        logger.warning(
-            "bad request streams %s not available",
-            set(mapping.keys()) - set(config.get_streams()),
-        )
-        raise HTTPException(
-            status_code=400,
-            detail=f"streams {set(mapping.keys()) - set(config.get_streams())} not available",
-        )
-    m = MappingSequence(
-        parts={MappingName("main"): mapping},
-        sequence=[MappingName("main")],
-        add_start_end=all_wrap,
-    )
-    if len(config.workers) < m.min_workers():
-        logger.warning(
-            "only %d workers available, but %d required",
-            len(config.workers),
-            m.min_workers(),
-        )
-        raise HTTPException(
-            status_code=400,
-            detail=f"only {len(config.workers)} workers available, but {m.min_workers()} required",
-        )
-    await ctrl.set_mapping(m)
-    return m.uuid
-
-
-@app.get("/api/v1/mapping")
-async def get_mapping() -> dict[str, Any]:
-    global ctrl
-    return {"parts": ctrl.mapping.parts, "sequence": ctrl.mapping.sequence}
-
-
-@app.post("/api/v1/sequence")
-async def set_sequence(
-    parts: dict[MappingName, dict[StreamName, list[Optional[list[VirtualWorker]]]]],
-    sequence: list[MappingName],
-    all_wrap: bool = True,
-) -> UUID4 | str:
-    global ctrl
-    config = await ctrl.get_configs()
-    m = MappingSequence(
-        parts=parts,
-        sequence=sequence,
-        add_start_end=all_wrap,
-    )
-    if m.all_streams - set(config.get_streams()) != set():
-        logger.warning(
-            "bad request streams %s not available",
-            m.all_streams - set(config.get_streams()),
-        )
-        raise HTTPException(
-            status_code=400,
-            detail=f"streams {m.all_streams - set(config.get_streams())} not available",
+    @app.get("/")
+    async def read_index() -> FileResponse:
+        return FileResponse(
+            os.path.join(os.path.dirname(__file__), "frontend", "index.html")
         )
 
-    if len(config.workers) < m.min_workers():
-        logger.warning(
-            "only %d workers available, but %d required",
-            len(config.workers),
-            m.min_workers(),
+    @app.get("/api/v1/mapping")
+    async def get_mapping(request: Request) -> dict[str, Any]:
+        ctrl = request.app.state.ctrl
+        return {"parts": ctrl.mapping.parts, "sequence": ctrl.mapping.sequence}
+
+    @app.post("/api/v1/sequence")
+    async def set_sequence(
+        request: Request,
+        parts: dict[MappingName, dict[StreamName, list[Optional[list[VirtualWorker]]]]],
+        sequence: list[MappingName],
+        all_wrap: bool = True,
+    ) -> UUID4 | str:
+        ctrl = request.app.state.ctrl
+        config = await ctrl.get_configs()
+        m = MappingSequence(
+            parts=parts,
+            sequence=sequence,
+            add_start_end=all_wrap,
         )
-        raise HTTPException(
-            status_code=400,
-            detail=f"only {len(config.workers)} workers available, but {m.min_workers()} required",
-        )
-    await ctrl.set_mapping(m)
-    return m.uuid
+        if m.all_streams - set(config.get_streams()) != set():
+            logger.warning(
+                "bad request streams %s not available",
+                m.all_streams - set(config.get_streams()),
+            )
+            raise HTTPException(
+                status_code=400,
+                detail=f"streams {m.all_streams - set(config.get_streams())} not available",
+            )
+
+        if len(config.workers) < m.min_workers():
+            logger.warning(
+                "only %d workers available, but %d required",
+                len(config.workers),
+                m.min_workers(),
+            )
+            raise HTTPException(
+                status_code=400,
+                detail=f"only {len(config.workers)} workers available, but {m.min_workers()} required",
+            )
+        await ctrl.set_mapping(m)
+        return m.uuid
+
+    @app.post("/api/v1/stop")
+    async def stop(request: Request) -> None:
+        logger.info("externally stopped scan")
+        request.app.state.ctrl.external_stop = True
+
+    async def log_streamer(ctrl):
+        latest = await ctrl.redis.xrevrange("dranspose_logs", count=1)
+        last = 0
+        if len(latest) > 0:
+            last = latest[0][0]
+
+        while True:
+            update_msgs = await ctrl.redis.xread({"dranspose_logs": last}, block=1300)
+            if "dranspose_logs" in update_msgs:
+                update_msg = update_msgs["dranspose_logs"][0][-1]
+                last = update_msg[0]
+                for log in update_msgs["dranspose_logs"][0]:
+                    yield json.dumps(log[1]) + "\n"
+
+    @app.get("/api/v1/log_stream")
+    async def get_log_stream(request: Request):
+        return StreamingResponse(log_streamer(request.app.state.ctrl))
+
+    @app.post("/api/v1/parameter/{name}")
+    async def post_param(request: Request, name: ParameterName) -> HashDigest:
+        data = await request.body()
+        logger.info("got %s: %s (len %d)", name, data[:100], len(data))
+        u = await request.app.state.ctrl.set_param(name, data)
+        return u
+
+    @app.get("/api/v1/parameter/{name}")
+    async def get_param(request: Request, name: ParameterName) -> Response:
+        ctrl = request.app.state.ctrl
+        if name not in ctrl.parameters:
+            raise HTTPException(status_code=404, detail="Parameter not found")
+
+        data = ctrl.parameters[name].data
+        return Response(data, media_type="application/x.bytes")
+
+    @app.get("/api/v1/parameters")
+    async def param_descr(request: Request) -> list[ParameterType]:
+        return await request.app.state.ctrl.describe_parameters()
+
+    routes_status(app)
+    routes_legacy(app)
+
+    return app
 
 
-@app.post("/api/v1/stop")
-async def stop() -> None:
-    global ctrl
-    logger.info("externally stopped scan")
-    ctrl.external_stop = True
-
-
-async def log_streamer():
-    latest = await ctrl.redis.xrevrange("dranspose_logs", count=1)
-    last = 0
-    if len(latest) > 0:
-        last = latest[0][0]
-
-    while True:
-        update_msgs = await ctrl.redis.xread({"dranspose_logs": last}, block=1300)
-        if "dranspose_logs" in update_msgs:
-            update_msg = update_msgs["dranspose_logs"][0][-1]
-            last = update_msg[0]
-            for log in update_msgs["dranspose_logs"][0]:
-                yield json.dumps(log[1]) + "\n"
-
-
-@app.get("/api/v1/log_stream")
-async def get_log_stream():
-    return StreamingResponse(log_streamer())
-
-
-@app.get("/api/v1/logs")
-async def get_logs(level: str = "INFO") -> Any:
-    global ctrl
-    data = await ctrl.redis.xrange("dranspose_logs", "-", "+")
-    logs = []
-    # TODO: once python 3.10 support is dropped, use
-    # levels = logging.getLevelNamesMapping()
-    levels = {
-        level: logging.__getattribute__(level)
-        for level in dir(logging)
-        if level.isupper() and isinstance(logging.__getattribute__(level), int)
-    }
-    minlevel = levels.get(level.upper(), logging.INFO)
-    for entry in data:
-        msglevel = levels[entry[1].get("levelname", "DEBUG")]
-        if msglevel >= minlevel:
-            logs.append(entry[1])
-    return logs
-
-
-@app.post("/api/v1/sardana_hook")
-async def set_sardana_hook(
-    info: dict[Literal["streams"] | Literal["scan"], Any]
-) -> UUID4 | str:
-    global ctrl
-    config = await ctrl.get_configs()
-    print(info)
-    if "scan" not in info:
-        return "no scan info"
-    if "nb_points" not in info["scan"]:
-        return "no nb_points in scan"
-    if "streams" not in info:
-        return "streams required"
-    for st in set(config.get_streams()).intersection(set(info["streams"])):
-        print("use stream", st)
-    logger.debug("create new mapping")
-    m = Map.from_uniform(
-        set(config.get_streams()).intersection(set(info["streams"])),
-        info["scan"]["nb_points"],
-    )
-    s = MappingSequence(
-        parts={MappingName("sardana"): m.mapping},
-        sequence=[MappingName("sardana")],
-        add_start_end=True,
-    )
-    logger.debug("set mapping")
-    await ctrl.set_mapping(s)
-    return s.uuid
-
-
-@app.post("/api/v1/parameter/{name}")
-async def post_param(request: Request, name: ParameterName) -> HashDigest:
-    data = await request.body()
-    logger.info("got %s: %s (len %d)", name, data[:100], len(data))
-    u = await ctrl.set_param(name, data)
-    return u
-
-
-@app.get("/api/v1/parameter/{name}")
-async def get_param(name: ParameterName) -> Response:
-    if name not in ctrl.parameters:
-        raise HTTPException(status_code=404, detail="Parameter not found")
-
-    data = ctrl.parameters[name].data
-    return Response(data, media_type="application/x.bytes")
-
-
-@app.get("/api/v1/parameters")
-async def param_descr() -> list[ParameterType]:
-    global ctrl
-    return await ctrl.describe_parameters()
+app = create_app()

--- a/dranspose/controller.py
+++ b/dranspose/controller.py
@@ -665,7 +665,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Clean up the ML models and release the resources
 
 
-def routes_legacy(app):
+def routes_legacy(app: FastAPI) -> None:
     @app.post("/api/v1/mapping")
     async def set_mapping(
         request: Request,
@@ -749,7 +749,7 @@ def routes_legacy(app):
         return s.uuid
 
 
-def routes_status(app):
+def routes_status(app: FastAPI) -> None:
     @app.get("/api/v1/config")
     async def get_configs(request: Request) -> EnsembleState:
         return await request.app.state.ctrl.get_configs()
@@ -849,7 +849,7 @@ def create_app() -> FastAPI:
         logger.info("externally stopped scan")
         request.app.state.ctrl.external_stop = True
 
-    async def log_streamer(ctrl) -> AsyncIterator[str]:
+    async def log_streamer(ctrl: Controller) -> AsyncIterator[str]:
         latest = await ctrl.redis.xrevrange("dranspose_logs", count=1)
         last = 0
         if len(latest) > 0:

--- a/dranspose/helpers/h5dict.py
+++ b/dranspose/helpers/h5dict.py
@@ -110,7 +110,7 @@ def _make_shape_type(obj: Any) -> tuple[H5Shape | None, H5Type | None]:
     else:
         try:
             arr = np.array(obj)
-            h5shape = H5SimpleShape(dims=arr.shape)
+            h5shape = H5SimpleShape(dims=list(arr.shape))
 
             if len(arr.dtype.descr) > 1:
                 # compound datatype
@@ -402,7 +402,7 @@ app = FastAPI()
 app.include_router(router)
 
 
-def get_data() -> Tuple[dict[str, Any], ContextManager]:
+def get_data() -> Tuple[dict[str, Any], ContextManager[None]]:
     dt = np.dtype({"names": ["a", "b"], "formats": [float, int]})
 
     arr = np.array([(0.5, 1)], dtype=dt)

--- a/dranspose/reducer.py
+++ b/dranspose/reducer.py
@@ -217,7 +217,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     run_task = asyncio.create_task(reducer.run())
     run_task.add_done_callback(done_callback)
 
-    def get_data() -> Tuple[dict[str, Any], ContextManager]:
+    def get_data() -> Tuple[dict[str, Any], ContextManager[None]]:
         data = {}
         lock = nullcontext()
         if reducer.reducer is not None:

--- a/dranspose/replay.py
+++ b/dranspose/replay.py
@@ -67,7 +67,7 @@ reducer_app = FastAPI()
 reducer: Any | None = None
 
 
-def get_data() -> Tuple[dict[str, Any], ContextManager]:
+def get_data() -> Tuple[dict[str, Any], ContextManager[None]]:
     global reducer
     data = {}
     lock = nullcontext()

--- a/dranspose/workload_generator.py
+++ b/dranspose/workload_generator.py
@@ -133,6 +133,7 @@ class WorkloadGenerator:
             raise Exception("must open socket before sending packets")
         if not isinstance(self.out_socket, AcquisitionSocket):
             raise Exception("must be AcquisitionSocket to send, is %s", self.out_socket)
+        logger.info("sending packets on socket %s", self.out_socket)
         acq = await self.out_socket.start(filename=spec.filename)
         logger.info("sending packets %s", spec)
         self.stat.packets += 1
@@ -156,10 +157,12 @@ class WorkloadGenerator:
 
     async def close_socket(self) -> None:
         if self.in_socket is not None:
+            logger.info("closing in_socket %s", self.in_socket)
             self.in_socket.close()
         if self.out_socket is not None:
+            logger.info("closing out_socket %s", self.out_socket.data_socket)
             await self.out_socket.close()
-        logger.info("socket closed")
+        logger.info("sockets closed")
 
     async def close(self) -> None:
         self.context.destroy(linger=0)

--- a/tests/stream1.py
+++ b/tests/stream1.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from typing import Any, Iterator, Optional
 
@@ -21,6 +22,7 @@ class Acquisition:
             "filename": self._filename,
             "msg_number": next(self._msg_number),
         }
+        logging.info("sending socket is %s", self._socket)
         if not meta:
             await self._socket.send_json(header)
         else:
@@ -69,6 +71,7 @@ class AcquisitionSocket:
         self.data_socket = ctx.socket(typ)
         self.data_socket.bind(str(bind))
         self.msg_number = itertools.count(0)
+        logging.info("bound acquisition socket %s to %s", self.data_socket, bind)
 
     async def start(self, filename: str, meta: Any = None) -> Acquisition:
         print("return acq")

--- a/tests/test_concurrent_restart_controller.py
+++ b/tests/test_concurrent_restart_controller.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
-import multiprocessing
-from typing import Any
+from tests.conftest import UvicornServer
 
 import aiohttp
 import pytest
@@ -11,20 +10,6 @@ from dranspose.protocol import (
     RedisKeys,
     EnsembleState,
 )
-
-
-class UvicornServer(multiprocessing.Process):
-    def __init__(self, config: uvicorn.Config):
-        super().__init__()
-        self.server = uvicorn.Server(config=config)
-        self.config = config
-
-    def stop(self) -> None:
-        self.terminate()
-
-    def run(self, *args: Any, **kwargs: Any) -> None:
-        self.server.run()
-
 
 # A lot of distributed state assumes that there is only ever one controller with the same prefix running per redis instance
 # This does not hold when redeploying on k8s as it starts the new container before the old is terminated.

--- a/tests/test_default_parameters.py
+++ b/tests/test_default_parameters.py
@@ -5,7 +5,6 @@ from typing import Callable, Optional, Awaitable, Sequence, Any
 import aiohttp
 import pytest
 
-from dranspose.ingester import Ingester
 from dranspose.parameters import ParameterList, ParameterBase, StrParameter
 from dranspose.protocol import WorkerName, ParameterName
 from dranspose.worker import Worker, WorkerSettings
@@ -29,8 +28,8 @@ async def test_default_params(
     controller: None,
     reducer: Callable[[Optional[str]], Awaitable[None]],
     create_worker: Callable[[Worker], Awaitable[Worker]],
-    create_ingester: Callable[[Ingester], Awaitable[Ingester]],
 ) -> None:
+    await reducer(None)
     await create_worker(
         Worker(
             settings=WorkerSettings(

--- a/tests/test_h5dict.py
+++ b/tests/test_h5dict.py
@@ -20,7 +20,7 @@ async def test_mapping() -> None:
 
     app.include_router(router, prefix="/results")
 
-    def get_data() -> Tuple[dict[str, Any], ContextManager]:
+    def get_data() -> Tuple[dict[str, Any], ContextManager[None]]:
         data = {
             "map": {
                 "x": [
@@ -183,7 +183,7 @@ async def test_root() -> None:
 
     app.include_router(router, prefix="/results")
 
-    def get_data() -> Tuple[dict[str, Any], ContextManager]:
+    def get_data() -> Tuple[dict[str, Any], ContextManager[None]]:
         dt = np.dtype({"names": ["a", "b"], "formats": [float, int]})
 
         arr = np.array([(0.5, 1)], dtype=dt)
@@ -273,7 +273,7 @@ async def test_slice() -> None:
 
     app.include_router(router, prefix="/results")
 
-    def get_data() -> Tuple[dict[str, Any], ContextManager]:
+    def get_data() -> Tuple[dict[str, Any], ContextManager[None]]:
         return {
             "image": [[r * 100 + c for c in range(10)] for r in range(10)],
         }, nullcontext()

--- a/tests/test_lecroy.py
+++ b/tests/test_lecroy.py
@@ -17,6 +17,7 @@ from dranspose.protocol import (
     StreamName,
     WorkerName,
     VirtualWorker,
+    ParameterName,
     VirtualConstraint,
 )
 
@@ -77,7 +78,9 @@ async def test_lecroy(
         )
     )
 
-    await wait_for_controller(streams={StreamName("lecroy")}, parameters={"channel"})
+    await wait_for_controller(
+        streams={StreamName("lecroy")}, parameters={ParameterName("channel")}
+    )
     async with aiohttp.ClientSession() as session:
         map = {
             "lecroy": [

--- a/tests/test_lecroy.py
+++ b/tests/test_lecroy.py
@@ -77,9 +77,7 @@ async def test_lecroy(
         )
     )
 
-    await wait_for_controller(
-        streams={StreamName("lecroy")}, parameters={"channel", "blub"}
-    )
+    await wait_for_controller(streams={StreamName("lecroy")}, parameters={"channel"})
     async with aiohttp.ClientSession() as session:
         map = {
             "lecroy": [

--- a/tests/test_maxrate.py
+++ b/tests/test_maxrate.py
@@ -37,16 +37,16 @@ async def test_simple(
     ],
 ) -> None:
     await reducer(None)
-    await create_worker(WorkerName("w1"), subprocess=True)  # type: ignore[call-arg]
-    await create_worker(WorkerName("w2"), subprocess=True)  # type: ignore[call-arg]
-    await create_worker(WorkerName("w3"), subprocess=True)  # type: ignore[call-arg]
-    await create_worker(WorkerName("w4"), subprocess=True)  # type: ignore[call-arg]
-    await create_worker(WorkerName("w5"), subprocess=True)  # type: ignore[call-arg]
-    await create_worker(WorkerName("w6"), subprocess=True)  # type: ignore[call-arg]
-    await create_worker(WorkerName("w7"), subprocess=True)  # type: ignore[call-arg]
-    await create_worker(WorkerName("w8"), subprocess=True)  # type: ignore[call-arg]
-    await create_worker(WorkerName("w9"), subprocess=True)  # type: ignore[call-arg]
-    await create_worker(WorkerName("w10"), subprocess=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w1"), threaded=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w2"), threaded=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w3"), threaded=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w4"), threaded=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w5"), threaded=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w6"), threaded=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w7"), threaded=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w8"), threaded=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w9"), threaded=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w10"), threaded=True)  # type: ignore[call-arg]
     await create_ingester(
         ZmqPullSingleIngester(
             settings=ZmqPullSingleSettings(
@@ -54,7 +54,7 @@ async def test_simple(
                 upstream_url=Url("tcp://localhost:9999"),
             ),
         ),
-        subprocess=True,  # type: ignore[call-arg]
+        threaded=True,  # type: ignore[call-arg]
     )
 
     await wait_for_controller(streams={StreamName("eiger")})

--- a/tests/test_multi_uvicorn.py
+++ b/tests/test_multi_uvicorn.py
@@ -21,7 +21,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     yield
 
 
-def create_app():
+def create_app() -> FastAPI:
     app = FastAPI(lifespan=lifespan)
 
     @app.get("/identity")

--- a/tests/test_multi_uvicorn.py
+++ b/tests/test_multi_uvicorn.py
@@ -1,0 +1,71 @@
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+import random
+from typing import AsyncGenerator
+
+from fastapi import FastAPI, Request
+
+import aiohttp
+
+import pytest
+import uvicorn
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    if hasattr(app.state, "identity"):
+        logging.warning("app state before startup %d", app.state.identity)
+    app.state.identity = random.randint(0, 10000000)
+    logging.warning("app state after set %d", app.state.identity)
+    yield
+
+
+def create_app():
+    app = FastAPI(lifespan=lifespan)
+
+    @app.get("/identity")
+    async def get_id(request: Request) -> int:
+        return request.app.state.identity
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_multi() -> None:
+    app1 = create_app()
+    config = uvicorn.Config(app1, port=5000, log_level="debug")
+    server = uvicorn.Server(config=config)
+    task = asyncio.create_task(server.serve())
+
+    await asyncio.sleep(1)
+
+    async with aiohttp.ClientSession() as session:
+        st = await session.get("http://localhost:5000/identity")
+        identity1before = await st.read()
+        logging.info("id of first is %s", identity1before)
+
+    app2 = create_app()
+    config2 = uvicorn.Config(app2, port=5001, log_level="debug")
+    server2 = uvicorn.Server(config=config2)
+    task2 = asyncio.create_task(server2.serve())
+
+    async with aiohttp.ClientSession() as session:
+        st = await session.get("http://localhost:5000/identity")
+        identity1after = await st.read()
+        logging.info("id of first after second started is %s", identity1after)
+
+    assert identity1before == identity1after
+
+    async with aiohttp.ClientSession() as session:
+        st = await session.get("http://localhost:5001/identity")
+        identity = await st.read()
+        logging.info("id of second is %s", identity)
+
+    assert identity1after != identity
+
+    server.should_exit = True
+    server2.should_exit = True
+
+    await task
+    await task2

--- a/tests/test_redis_logs.py
+++ b/tests/test_redis_logs.py
@@ -45,4 +45,4 @@ async def test_logs(
         lgs = await logs.json()
         # assert len(lgs) > 0 currently there is nothing written to redis from a test, but it works when called from cli
         for log in lgs:
-            assert log["levelname"] == "WARNING"
+            assert log["levelname"] in ["WARNING", "ERROR"]

--- a/tests/test_reducer_lock.py
+++ b/tests/test_reducer_lock.py
@@ -24,7 +24,7 @@ test_done = threading.Event()
 
 class BlockingReducer:
     def __init__(self, **kwargs: dict[str, object]) -> None:
-        self.publish: dict[str, dict[int, int]] = {"map": {}}
+        self.publish: dict[str, dict[str, int]] = {"map": {}}
 
         self.rw_lock = RWLockFair()
         self.publish_rlock = self.rw_lock.gen_rlock()

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -35,10 +35,7 @@ from dranspose.worker import Worker
 from tests.utils import wait_for_controller, wait_for_finish
 
 
-@pytest.mark.skipif("config.getoption('rust')", reason="rust does not support dumping")
-@pytest.mark.asyncio
-async def test_replay(
-    controller: None,
+async def dump_data(
     reducer: Callable[[Optional[str]], Awaitable[None]],
     create_worker: Callable[[WorkerName], Awaitable[Worker]],
     create_ingester: Callable[[Ingester], Awaitable[Ingester]],
@@ -46,7 +43,7 @@ async def test_replay(
     stream_orca: Callable[[zmq.Context[Any], int, int], Coroutine[Any, Any, None]],
     stream_small: Callable[[zmq.Context[Any], int, int], Coroutine[Any, Any, None]],
     tmp_path: Any,
-) -> None:
+):
     await reducer(None)
     await create_worker(WorkerName("w1"))
     await create_worker(WorkerName("w2"))
@@ -168,12 +165,43 @@ async def test_replay(
 
     await wait_for_finish()
 
-    # read dump
+    context.destroy()
 
+    return p_eiger, p_prefix, uuid
+
+
+def generate_params(tmp_path):
     par_file = tmp_path / "parameters.json"
 
     with open(par_file, "w") as f:
         json.dump([{"name": "roi1", "data": "[10,20]"}], f)
+    return par_file
+
+
+@pytest.mark.skipif("config.getoption('rust')", reason="rust does not support dumping")
+@pytest.mark.asyncio
+async def test_replay(
+    controller: None,
+    reducer: Callable[[Optional[str]], Awaitable[None]],
+    create_worker: Callable[[WorkerName], Awaitable[Worker]],
+    create_ingester: Callable[[Ingester], Awaitable[Ingester]],
+    stream_eiger: Callable[[zmq.Context[Any], int, int], Coroutine[Any, Any, None]],
+    stream_orca: Callable[[zmq.Context[Any], int, int], Coroutine[Any, Any, None]],
+    stream_small: Callable[[zmq.Context[Any], int, int], Coroutine[Any, Any, None]],
+    tmp_path: Any,
+) -> None:
+    p_eiger, p_prefix, uuid = await dump_data(
+        reducer,
+        create_worker,
+        create_ingester,
+        stream_eiger,
+        stream_orca,
+        stream_small,
+        tmp_path,
+    )
+    # read dump
+
+    par_file = generate_params(tmp_path)
 
     replay(
         "examples.dummy.worker:FluorescenceWorker",
@@ -183,12 +211,37 @@ async def test_replay(
         par_file,
     )
 
+
+@pytest.mark.skipif("config.getoption('rust')", reason="rust does not support dumping")
+@pytest.mark.asyncio
+async def test_replay_gzip(
+    controller: None,
+    reducer: Callable[[Optional[str]], Awaitable[None]],
+    create_worker: Callable[[WorkerName], Awaitable[Worker]],
+    create_ingester: Callable[[Ingester], Awaitable[Ingester]],
+    stream_eiger: Callable[[zmq.Context[Any], int, int], Coroutine[Any, Any, None]],
+    stream_orca: Callable[[zmq.Context[Any], int, int], Coroutine[Any, Any, None]],
+    stream_small: Callable[[zmq.Context[Any], int, int], Coroutine[Any, Any, None]],
+    tmp_path: Any,
+) -> None:
+    p_eiger, p_prefix, uuid = await dump_data(
+        reducer,
+        create_worker,
+        create_ingester,
+        stream_eiger,
+        stream_orca,
+        stream_small,
+        tmp_path,
+    )
+
     with open(f"{p_prefix}orca-ingester-{uuid}.cbors", "rb") as f_in:
         with gzip.open(f"{p_prefix}orca-ingester-{uuid}.cbors.gz", "wb") as f_out:
             shutil.copyfileobj(f_in, f_out)
 
     stop_event = threading.Event()
     done_event = threading.Event()
+
+    par_file = generate_params(tmp_path)
 
     thread = threading.Thread(
         target=replay,
@@ -208,11 +261,14 @@ async def test_replay(
     logging.info("replay done")
 
     async with aiohttp.ClientSession() as session:
+        ntrig = 10
         st = await session.get("http://localhost:5010/api/v1/result/")
         content = await st.content.read()
         result = pickle.loads(content)[0]
         assert list(result["results"].keys()) == list(range(ntrig + 1))
-        logging.warning("params in reducer is %s", result["results"][5][0])
+        logging.warning(
+            "params in reducer is %s", result["results"][5][0].streams.keys()
+        )
         ev5: EventData = result["results"][5][0]
         assert ev5.event_number == 5
         assert ev5.streams[StreamName("eiger")].typ == "STINS"
@@ -237,6 +293,29 @@ async def test_replay(
     stop_event.set()
 
     thread.join()
+
+
+@pytest.mark.skipif("config.getoption('rust')", reason="rust does not support dumping")
+@pytest.mark.asyncio
+async def test_replay_pklparam(
+    controller: None,
+    reducer: Callable[[Optional[str]], Awaitable[None]],
+    create_worker: Callable[[WorkerName], Awaitable[Worker]],
+    create_ingester: Callable[[Ingester], Awaitable[Ingester]],
+    stream_eiger: Callable[[zmq.Context[Any], int, int], Coroutine[Any, Any, None]],
+    stream_orca: Callable[[zmq.Context[Any], int, int], Coroutine[Any, Any, None]],
+    stream_small: Callable[[zmq.Context[Any], int, int], Coroutine[Any, Any, None]],
+    tmp_path: Any,
+) -> None:
+    p_eiger, p_prefix, uuid = await dump_data(
+        reducer,
+        create_worker,
+        create_ingester,
+        stream_eiger,
+        stream_orca,
+        stream_small,
+        tmp_path,
+    )
 
     bin_file = tmp_path / "binparams.pkl"
 
@@ -285,6 +364,29 @@ async def test_replay(
 
     thread.join()
 
+
+@pytest.mark.skipif("config.getoption('rust')", reason="rust does not support dumping")
+@pytest.mark.asyncio
+async def test_replay_cborparam(
+    controller: None,
+    reducer: Callable[[Optional[str]], Awaitable[None]],
+    create_worker: Callable[[WorkerName], Awaitable[Worker]],
+    create_ingester: Callable[[Ingester], Awaitable[Ingester]],
+    stream_eiger: Callable[[zmq.Context[Any], int, int], Coroutine[Any, Any, None]],
+    stream_orca: Callable[[zmq.Context[Any], int, int], Coroutine[Any, Any, None]],
+    stream_small: Callable[[zmq.Context[Any], int, int], Coroutine[Any, Any, None]],
+    tmp_path: Any,
+) -> None:
+    p_eiger, p_prefix, uuid = await dump_data(
+        reducer,
+        create_worker,
+        create_ingester,
+        stream_eiger,
+        stream_orca,
+        stream_small,
+        tmp_path,
+    )
+
     cbor_file = tmp_path / "binparams.cbor"
 
     with open(cbor_file, mode="wb") as fb:
@@ -330,7 +432,3 @@ async def test_replay(
     stop_event.set()
 
     thread.join()
-
-    context.destroy()
-
-    print(content)

--- a/tests/test_rust_ingest.py
+++ b/tests/test_rust_ingest.py
@@ -28,16 +28,16 @@ async def test_rust_basic(
     ],
 ) -> None:
     await reducer(None)
-    await create_worker(WorkerName("w1"), subprocess=True)  # type: ignore[call-arg]
-    await create_worker(WorkerName("w2"), subprocess=True)  # type: ignore[call-arg]
-    await create_worker(WorkerName("w3"), subprocess=True)  # type: ignore[call-arg]
-    await create_worker(WorkerName("w4"), subprocess=True)  # type: ignore[call-arg]
-    await create_worker(WorkerName("w5"), subprocess=True)  # type: ignore[call-arg]
-    await create_worker(WorkerName("w6"), subprocess=True)  # type: ignore[call-arg]
-    await create_worker(WorkerName("w7"), subprocess=True)  # type: ignore[call-arg]
-    await create_worker(WorkerName("w8"), subprocess=True)  # type: ignore[call-arg]
-    await create_worker(WorkerName("w9"), subprocess=True)  # type: ignore[call-arg]
-    await create_worker(WorkerName("w10"), subprocess=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w1"), threaded=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w2"), threaded=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w3"), threaded=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w4"), threaded=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w5"), threaded=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w6"), threaded=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w7"), threaded=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w8"), threaded=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w9"), threaded=True)  # type: ignore[call-arg]
+    await create_worker(WorkerName("w10"), threaded=True)  # type: ignore[call-arg]
 
     await asyncio.sleep(2)
 

--- a/tests/test_unit_h5dict.py
+++ b/tests/test_unit_h5dict.py
@@ -1,25 +1,29 @@
 import logging
 from contextlib import nullcontext
 from types import SimpleNamespace
+from typing import ContextManager, Any, cast
+from fastapi import Request
+from starlette.responses import Response
 
 from dranspose.helpers.h5dict import datasets, _path_to_uuid, values, attribute
+from dranspose.helpers.h5types import H5SimpleShape
 
 
-def fake_state():
+def fake_state() -> Request:
     req = SimpleNamespace()
     setattr(req, "app", SimpleNamespace())
     setattr(req, "headers", dict())
     setattr(req.app, "state", SimpleNamespace())
     setattr(req.app.state, "get_data", None)
-    return req
+    return cast(Request, req)
 
 
-def test_datasets():
+def test_datasets() -> None:
     req = fake_state()
 
     target = [[1, 2], [3, 4], [5, 6]]
 
-    def get_data():
+    def get_data() -> tuple[dict[str, Any], ContextManager[None]]:
         return {"bla": target}, nullcontext()
 
     req.app.state.get_data = get_data
@@ -27,18 +31,19 @@ def test_datasets():
     uuid = _path_to_uuid(["bla"], "g-")
     r = datasets(req, uuid)
     logging.info("ret %s", r.model_dump_json())
+    assert isinstance(r.shape, H5SimpleShape)
     assert r.shape.dims == [3, 2]
     target.append([-1, -2])
     assert r.shape.dims == [3, 2]
     logging.info("ret %s", r.model_dump_json())
 
 
-def test_value_strlist():
+def test_value_strlist() -> None:
     req = fake_state()
 
     target = ["hi", "there"]
 
-    def get_data():
+    def get_data() -> tuple[dict[str, Any], ContextManager[None]]:
         return {"bla": target}, nullcontext()
 
     req.app.state.get_data = get_data
@@ -51,18 +56,19 @@ def test_value_strlist():
     assert r == {"value": ["hi", "there"]}
 
 
-def test_value_intlist():
+def test_value_intlist() -> None:
     req = fake_state()
 
     target = [1, 2, 3, 4]
 
-    def get_data():
+    def get_data() -> tuple[dict[str, Any], ContextManager[None]]:
         return {"bla": target}, nullcontext()
 
     req.app.state.get_data = get_data
 
     uuid = _path_to_uuid(["bla"], "d-")
     r = values(req, uuid)
+    assert isinstance(r, Response)
     logging.info("ret %s", r.body)
     assert (
         r.body
@@ -75,12 +81,12 @@ def test_value_intlist():
     )
 
 
-def test_attribute():
+def test_attribute() -> None:
     req = fake_state()
 
     target = [1, 2, 3, 4]
 
-    def get_data():
+    def get_data() -> tuple[dict[str, Any], ContextManager[None]]:
         return {"bla": 2, "bla_attrs": {"test": target}}, nullcontext()
 
     req.app.state.get_data = get_data
@@ -89,6 +95,7 @@ def test_attribute():
     r = attribute(req, "datasets", uuid, "test")
     logging.info("ret %s", r)
     assert r.value == [1, 2, 3, 4]
+    assert isinstance(r.shape, H5SimpleShape)
     assert r.shape.dims == [4]
     target[1] = 5
     target.append(10)

--- a/tests/test_workload.py
+++ b/tests/test_workload.py
@@ -121,10 +121,13 @@ async def test_sink(
     workload_generator: Callable[[Optional[int]], Awaitable[None]]
 ) -> None:
     await workload_generator(5003)
+    logging.debug("start gen at 5004")
     await workload_generator(5004)
 
     async with aiohttp.ClientSession() as session:
         nframes = 100
+
+        logging.debug("opening PUSH on 9999 at 5003")
 
         st = await session.post(
             "http://localhost:5003/api/v1/open_socket",
@@ -133,6 +136,7 @@ async def test_sink(
         state = await st.json()
         logging.info("open %s", state)
 
+        logging.debug("connect PULL to 127.0.0.1:9999 at 5004")
         st = await session.post(
             "http://localhost:5004/api/v1/connect_socket",
             json={"type": zmq.PULL, "url": "tcp://127.0.0.1:9999"},

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -43,11 +43,17 @@ async def wait_for_controller(
         if parameters is None:
             parameters = set()
         for param in parameters:
+            timeout = 0
             resp = await session.get(f"{controller}api/v1/parameter/{param}")
             while resp.status != 200:
                 await asyncio.sleep(1)
+                timeout += 1
                 logging.warning("waiting for parameter %s", param)
                 resp = await session.get(f"{controller}api/v1/parameter/{param}")
+                if timeout > 20:
+                    logging.error("parameter %s is not available", param)
+                    raise TimeoutError("failed to bring up parameters")
+            logging.info("parameter %s is available", param)
 
         return state
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,12 +6,13 @@ import aiohttp
 
 from pydantic_core import Url
 
-from dranspose.protocol import EnsembleState, StreamName, WorkerName
+from dranspose.protocol import EnsembleState, StreamName, WorkerName, ParameterName
 
 
 async def wait_for_controller(
     streams: Optional[set[StreamName]] = None,
     workers: Optional[set[WorkerName]] = None,
+    parameters: Optional[set[ParameterName]] = None,
     controller: Url = Url("http://localhost:5000"),
 ) -> EnsembleState:
     async with aiohttp.ClientSession() as session:
@@ -38,6 +39,15 @@ async def wait_for_controller(
                     "streams %s and workers %s are not available", streams, workers
                 )
                 raise TimeoutError("failed to bring up components")
+
+        if parameters is None:
+            parameters = set()
+        for param in parameters:
+            resp = await session.get(f"{controller}api/v1/parameter/{param}")
+            while resp.status != 200:
+                await asyncio.sleep(1)
+                logging.warning("waiting for parameter %s", param)
+                resp = await session.get(f"{controller}api/v1/parameter/{param}")
 
         return state
 


### PR DESCRIPTION
Multiprocessing with the default linux fork gets tricky and will be deprecated.
This tries to use threads instead of processes to get rid of the following warning:

python3.13/multiprocessing/popen_fork.py:67: DeprecationWarning: This process (pid=2552) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()