### PR TITLE
Added docs publishing CI

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,11 +1,9 @@
 name: Publish docs
 
 on:
-  [push]
-
-#:
-#    branches:
-#      - main
+  push:
+    branches:
+      - main
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
Currently builds docs on pushes to `main`. 

Added docs dependencies into CI script to avoid need to install all the `dranspose` dependencies when building the docs. 

