### PR TITLE
fix: Use REDIS_URL env var throughout tests, fixes #35

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1011,8 +1011,9 @@ def sample_table_to_html(
 
 
 async def sample_redis(filename: str) -> None:
-    r = redis.Redis(host="localhost", port=6379, decode_responses=True, protocol=3)
-    r_raw = redis.Redis(host="localhost", port=6379, decode_responses=False, protocol=3)
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    r = redis.from_url(redis_url, decode_responses=True, protocol=3)
+    r_raw = redis.from_url(redis_url, decode_responses=False, protocol=3)
     table: dict[str, Any] = {}
     try:
         tick = 0

--- a/tests/test_concurrent_restart_controller.py
+++ b/tests/test_concurrent_restart_controller.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 
 import aiohttp
 import pytest
@@ -25,7 +26,8 @@ async def test_restart() -> None:
     og_server = uvicorn.Server(config=og_config)
     og_task = asyncio.create_task(og_server.serve())
 
-    r = redis.Redis(host="localhost", port=6379, decode_responses=True, protocol=3)
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    r = redis.from_url(redis_url, decode_responses=True, protocol=3)
 
     async with aiohttp.ClientSession() as session:
         running = False

--- a/tests/test_redis_clock.py
+++ b/tests/test_redis_clock.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 
 import pytest
 
@@ -9,7 +10,8 @@ import redis.asyncio as redis
 
 @pytest.mark.asyncio
 async def test_distributed() -> None:
-    r = redis.Redis(host="localhost", port=6379, decode_responses=True, protocol=3)
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    r = redis.from_url(redis_url, decode_responses=True, protocol=3)
 
     keys = await r.keys("dranspose:*")
     logging.info("keys %s", keys)

--- a/tests/test_redis_empty.py
+++ b/tests/test_redis_empty.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import pytest
 
@@ -8,8 +9,9 @@ import redis.asyncio as redis
 
 @pytest.mark.asyncio
 async def test_distributed() -> None:
-    r = redis.Redis(host="localhost", port=6379, decode_responses=True, protocol=3)
-    raw_redis = redis.from_url("redis://localhost:6379/0?protocol=3")
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    r = redis.from_url(redis_url, decode_responses=True, protocol=3)
+    raw_redis = redis.from_url(redis_url, decode_responses=False, protocol=3)
 
     keys = await r.keys("dranspose:*")
     logging.info("keys %s", keys)


### PR DESCRIPTION
Tested both with standard port, and after using: 

```
podman run  -p 7000:6379 redis
```

with 

```
REDIS_URL="redis://localhost:7000/0" uv run python -m pytest
```

(oddly, the `uv run pytest` command wouldn't work even though it's listed in the environment commands :man_shrugging: ) 
