### PR TITLE
/api/v1/mapping/ => /api/v1/sequence, and helper for tests

### DIFF
--- a/docs/deployment/sardana.md
+++ b/docs/deployment/sardana.md
@@ -47,7 +47,8 @@ class dranspose(Macro):
                 mapping["sardana"] = [[{"constraint":i}] if 
                                       i%burst==burst-1 else 
                                       None for i in range(burst*steps)]
-                req = requests.post(f"{url}/api/v1/mapping", json=mapping)
+                sequence = {"parts" : {"main": mapping}, "sequence": ["main"]}
+                req = requests.post(f"{url}/api/v1/sequence", json=sequence)
                 self.output(f"{req.status_code}, msg: {req.content}")
 ```
 

--- a/dranspose/cli.py
+++ b/dranspose/cli.py
@@ -332,7 +332,9 @@ def run() -> None:
                 )
                 root_logger.addHandler(handler)
             except ConnectionError:
-                root_logger.critical(f"Can't connect to {settings.redis_dsn}. Is redis running?")
+                root_logger.critical(
+                    f"Can't connect to {settings.redis_dsn}. Is redis running?"
+                )
                 exit(1)
         args.func(args)
 

--- a/dranspose/controller.py
+++ b/dranspose/controller.py
@@ -804,6 +804,11 @@ def create_app() -> FastAPI:
 
     @app.get("/api/v1/mapping")
     async def get_mapping(request: Request) -> dict[str, Any]:
+        """ alias for backwards compatability """
+        return await get_sequence(request)
+
+    @app.get("/api/v1/sequence")
+    async def get_sequence(request: Request) -> dict[str, Any]:
         ctrl = request.app.state.ctrl
         return {"parts": ctrl.mapping.parts, "sequence": ctrl.mapping.sequence}
 

--- a/dranspose/controller.py
+++ b/dranspose/controller.py
@@ -804,7 +804,7 @@ def create_app() -> FastAPI:
 
     @app.get("/api/v1/mapping")
     async def get_mapping(request: Request) -> dict[str, Any]:
-        """ alias for backwards compatability """
+        """alias for backwards compatability"""
         return await get_sequence(request)
 
     @app.get("/api/v1/sequence")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -437,9 +437,9 @@ async def stream_eiger() -> (
         for frameno in range(nframes):
             img = np.zeros((width, height), dtype=np.uint16)
             for _ in range(20):
-                img[random.randint(0, width - 1)][random.randint(0, height - 1)] = (
-                    random.randint(0, 10)
-                )
+                img[random.randint(0, width - 1)][
+                    random.randint(0, height - 1)
+                ] = random.randint(0, 10)
             extra = {"timestamps": {"dummy": datetime.now(timezone.utc).isoformat()}}
             await acq.image(img, img.shape, frameno, extra_fields=extra)
             await asyncio.sleep(frame_time)
@@ -521,9 +521,9 @@ async def stream_orca() -> (
         for frameno in range(nframes):
             img = np.zeros((width, height), dtype=np.uint16)
             for _ in range(20):
-                img[random.randint(0, width - 1)][random.randint(0, height - 1)] = (
-                    random.randint(0, 10)
-                )
+                img[random.randint(0, width - 1)][
+                    random.randint(0, height - 1)
+                ] = random.randint(0, 10)
             await acq.image(img, img.shape, frameno)
             await asyncio.sleep(0.1)
         await acq.close()

--- a/tests/test_albaem.py
+++ b/tests/test_albaem.py
@@ -19,7 +19,7 @@ from dranspose.protocol import (
 )
 
 from dranspose.worker import Worker
-from tests.utils import wait_for_controller, wait_for_finish
+from tests.utils import wait_for_controller, wait_for_finish, set_uniform_sequence
 
 
 @pytest.mark.asyncio
@@ -45,23 +45,7 @@ async def test_albaem(
     )
 
     await wait_for_controller(streams={StreamName("albaem")})
-    async with aiohttp.ClientSession() as session:
-        ntrig = 5
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
-                "albaem": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(2 * i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(1, ntrig)
-                ],
-            },
-        )
-        assert resp.status == 200
-        await resp.json()
+    await set_uniform_sequence(streams={StreamName("albaem")}, ntrig=5)
 
     context = zmq.asyncio.Context()
 

--- a/tests/test_albaem.py
+++ b/tests/test_albaem.py
@@ -3,7 +3,6 @@ import os
 from pathlib import PosixPath
 from typing import Awaitable, Callable, Coroutine, Optional, Any
 
-import aiohttp
 import zmq.asyncio
 
 import pytest
@@ -14,8 +13,6 @@ from dranspose.ingesters.zmqsub_albaem import ZmqSubAlbaemIngester, ZmqSubAlbaem
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 
 from dranspose.worker import Worker

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -29,7 +29,7 @@ import redis.asyncio as redis
 
 from dranspose.worker import Worker
 
-from tests.utils import wait_for_controller, wait_for_finish
+from tests.utils import wait_for_controller, wait_for_finish, set_uniform_sequence
 
 
 @pytest.mark.asyncio
@@ -54,29 +54,11 @@ async def test_simple(
 
     redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
     r = redis.from_url(redis_url, decode_responses=True, protocol=3)
-
-    async with aiohttp.ClientSession() as session:
-        await wait_for_controller(
-            streams={StreamName("eiger")}, workers={WorkerName("w1")}
-        )
-
-        ntrig = 10
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
-                "eiger": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(2 * i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(1, ntrig)
-                ],
-            },
-        )
-        assert resp.status == 200
-        uuid = await resp.json()
-
+    await wait_for_controller(
+        streams={StreamName("eiger")}, workers={WorkerName("w1")}
+    )
+    ntrig = 10
+    uuid = await set_uniform_sequence(streams={StreamName("eiger")}, ntrig=ntrig)
     updates = await r.xread({RedisKeys.updates(): 0})
     assert "dranspose:controller:updates" in updates
     assert json.loads(updates["dranspose:controller:updates"][-1][-1][1]["data"]) == {

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -58,9 +58,7 @@ async def test_simple(
 
     redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
     r = redis.from_url(redis_url, decode_responses=True, protocol=3)
-    await wait_for_controller(
-        streams={StreamName("eiger")}, workers={WorkerName("w1")}
-    )
+    await wait_for_controller(streams={StreamName("eiger")}, workers={WorkerName("w1")})
     ntrig = 10
     uuid = await set_uniform_sequence(streams={StreamName("eiger")}, ntrig=ntrig)
     updates = await r.xread({RedisKeys.updates(): 0})
@@ -169,17 +167,19 @@ async def test_map(
         ntrig = 10
         resp = await session.post(
             "http://localhost:5000/api/v1/sequence",
-            json=monopart_sequence({
-                "eiger": [ [ vworker(2 * i) ] for i in range(1, ntrig) ],
-                "orca": [ [ vworker(2 * i + 1) ] for i in range(1, ntrig) ],
-                "alba": [ [ vworker(2 * i), vworker(2 * i + 1) ] for i in range(1, ntrig) ],
-                "slow": [
-                    [ vworker(2 * i), vworker(2 * i + 1) ]
-                    if i % 4 == 0
-                    else None
-                    for i in range(1, ntrig)
-                ],
-            }),
+            json=monopart_sequence(
+                {
+                    "eiger": [[vworker(2 * i)] for i in range(1, ntrig)],
+                    "orca": [[vworker(2 * i + 1)] for i in range(1, ntrig)],
+                    "alba": [
+                        [vworker(2 * i), vworker(2 * i + 1)] for i in range(1, ntrig)
+                    ],
+                    "slow": [
+                        [vworker(2 * i), vworker(2 * i + 1)] if i % 4 == 0 else None
+                        for i in range(1, ntrig)
+                    ],
+                }
+            ),
         )
         assert resp.status == 200
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -10,11 +10,9 @@ from dranspose.ingesters.zmqpull_single import (
     ZmqPullSingleSettings,
 )
 from dranspose.protocol import (
-    VirtualWorker,
-    VirtualConstraint,
     StreamName,
 )
-from tests.utils import wait_for_controller, uniform_sequence, set_uniform_sequence
+from tests.utils import wait_for_controller, uniform_sequence
 
 
 @pytest.mark.asyncio
@@ -55,7 +53,9 @@ async def test_not_enough_workers(
     async with aiohttp.ClientSession() as session:
         ntrig = 10
         sequence = uniform_sequence({StreamName("eiger")}, ntrig)
-        resp = await session.post("http://localhost:5000/api/v1/sequence/", json=sequence)
+        resp = await session.post(
+            "http://localhost:5000/api/v1/sequence/", json=sequence
+        )
         assert resp.status == 400
         response = await resp.json()
         assert {"detail": "only 0 workers available, but 1 required"} == response

--- a/tests/test_custom_ingester.py
+++ b/tests/test_custom_ingester.py
@@ -24,7 +24,7 @@ from dranspose.protocol import (
 )
 from dranspose.worker import Worker, WorkerSettings
 from examples.dummy.sw_trig_ingester import SoftTriggerPcapIngester
-from tests.utils import wait_for_controller, wait_for_finish
+from tests.utils import wait_for_controller, wait_for_finish, set_uniform_sequence
 
 
 @pytest.mark.asyncio
@@ -73,38 +73,8 @@ async def test_ingester(
     )
 
     await wait_for_controller(streams={StreamName("contrast"), StreamName("pcap")})
-    async with aiohttp.ClientSession() as session:
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
-                "contrast": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(ntrig)
-                ],
-                "pcap": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(ntrig)
-                ],
-                "dummy": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(ntrig)
-                ],
-            },
-        )
-        assert resp.status == 200
-        await resp.json()
+    await set_uniform_sequence(["contrast", "pcap", "dummy"], ntrig=ntrig-1)
+
 
     context = zmq.asyncio.Context()
 

--- a/tests/test_custom_ingester.py
+++ b/tests/test_custom_ingester.py
@@ -6,7 +6,6 @@ import asyncio
 from typing import Awaitable, Callable, Any, Coroutine, Optional
 import zmq.asyncio
 
-import aiohttp
 import pytest
 from pydantic_core import Url
 
@@ -19,8 +18,6 @@ from dranspose.ingesters.zmqsub_contrast import (
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 from dranspose.worker import Worker, WorkerSettings
 from examples.dummy.sw_trig_ingester import SoftTriggerPcapIngester
@@ -73,8 +70,7 @@ async def test_ingester(
     )
 
     await wait_for_controller(streams={StreamName("contrast"), StreamName("pcap")})
-    await set_uniform_sequence(["contrast", "pcap", "dummy"], ntrig=ntrig-1)
-
+    await set_uniform_sequence(["contrast", "pcap", "dummy"], ntrig=ntrig - 1)
 
     context = zmq.asyncio.Context()
 

--- a/tests/test_debugworker.py
+++ b/tests/test_debugworker.py
@@ -21,9 +21,6 @@ from dranspose.middlewares import stream1
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
-    WorkerTag,
 )
 
 from dranspose.worker import Worker
@@ -81,14 +78,16 @@ async def test_debug(
         ntrig = 10
         resp = await session.post(
             "http://localhost:5000/api/v1/sequence",
-            json=monopart_sequence({
-                "eiger": [
-                    [vworker(2 * i)]
-                    if i % 4 != 0
-                    else [vworker(2 * i), vworker(tags={"debug"})]
-                    for i in range(1, ntrig)
-                ],
-            }),
+            json=monopart_sequence(
+                {
+                    "eiger": [
+                        [vworker(2 * i)]
+                        if i % 4 != 0
+                        else [vworker(2 * i), vworker(tags={"debug"})]
+                        for i in range(1, ntrig)
+                    ],
+                }
+            ),
         )
         assert resp.status == 200
         await resp.json()

--- a/tests/test_discard_scan.py
+++ b/tests/test_discard_scan.py
@@ -54,14 +54,14 @@ async def test_simple(
         ntrig = 10
         resp = await session.post(
             "http://localhost:5000/api/v1/sequence",
-            json=monopart_sequence({
-                "eiger": [
-                    []
-                    if 3 < i < 8
-                    else [vworker(constraint=i, tags=["debug"])]
-                    for i in range(1, ntrig)
-                ],
-            }),
+            json=monopart_sequence(
+                {
+                    "eiger": [
+                        [] if 3 < i < 8 else [vworker(constraint=i, tags=["debug"])]
+                        for i in range(1, ntrig)
+                    ],
+                }
+            ),
         )
         assert resp.status == 200
 

--- a/tests/test_discard_scan.py
+++ b/tests/test_discard_scan.py
@@ -22,12 +22,10 @@ from dranspose.middlewares.stream1 import parse
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    WorkerTag,
 )
 
 from dranspose.worker import Worker
-from tests.utils import wait_for_controller, wait_for_finish
+from tests.utils import wait_for_controller, wait_for_finish, vworker, monopart_sequence
 
 
 @pytest.mark.asyncio
@@ -55,17 +53,15 @@ async def test_simple(
     async with aiohttp.ClientSession() as session:
         ntrig = 10
         resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
+            "http://localhost:5000/api/v1/sequence",
+            json=monopart_sequence({
                 "eiger": [
                     []
                     if 3 < i < 8
-                    else [
-                        VirtualWorker(tags={WorkerTag("debug")}).model_dump(mode="json")
-                    ]
+                    else [vworker(constraint=i, tags=["debug"])]
                     for i in range(1, ntrig)
                 ],
-            },
+            }),
         )
         assert resp.status == 200
 

--- a/tests/test_dumping.py
+++ b/tests/test_dumping.py
@@ -102,8 +102,7 @@ async def test_dump(
     )
     async with aiohttp.ClientSession() as session:
         p_prefix = tmp_path / "dump_"
-        logging.info("prefix is %s encoded: %s", p_prefix,
-                     str(p_prefix).encode("utf8"))
+        logging.info("prefix is %s encoded: %s", p_prefix, str(p_prefix).encode("utf8"))
 
         resp = await session.post(
             "http://localhost:5000/api/v1/parameter/dump_prefix",
@@ -112,7 +111,8 @@ async def test_dump(
         assert resp.status == 200
 
         ntrig = 10
-        payload = monopart_sequence({
+        payload = monopart_sequence(
+            {
                 "eiger": [
                     [
                         VirtualWorker(constraint=VirtualConstraint(2 * i)).model_dump(
@@ -153,11 +153,9 @@ async def test_dump(
                     else None
                     for i in range(1, ntrig)
                 ],
-        })
-        resp = await session.post(
-            "http://localhost:5000/api/v1/sequence",
-            json=payload
+            }
         )
+        resp = await session.post("http://localhost:5000/api/v1/sequence", json=payload)
         assert resp.status == 200
         uuid = await resp.json()
 
@@ -236,8 +234,7 @@ async def test_dump_xrd(
     await wait_for_controller(streams={StreamName("xrd")})
     async with aiohttp.ClientSession() as session:
         p_prefix = tmp_path / "dump_"
-        logging.info("prefix is %s encoded: %s", p_prefix,
-                     str(p_prefix).encode("utf8"))
+        logging.info("prefix is %s encoded: %s", p_prefix, str(p_prefix).encode("utf8"))
 
         resp = await session.post(
             "http://localhost:5000/api/v1/parameter/dump_prefix",
@@ -288,8 +285,7 @@ async def test_dump_map_and_parameters(
     await wait_for_controller(streams={StreamName("xrd")})
     async with aiohttp.ClientSession() as session:
         p_prefix = tmp_path / "dump_"
-        logging.info("prefix is %s encoded: %s", p_prefix,
-                     str(p_prefix).encode("utf8"))
+        logging.info("prefix is %s encoded: %s", p_prefix, str(p_prefix).encode("utf8"))
 
         pars = {
             "dump_prefix": str(p_prefix).encode("utf8"),

--- a/tests/test_dumping.py
+++ b/tests/test_dumping.py
@@ -308,7 +308,7 @@ async def test_dump_map_and_parameters(
     context = zmq.asyncio.Context()
 
     async with aiohttp.ClientSession() as session:
-        st = await session.get("http://localhost:5000/api/v1/mapping")
+        st = await session.get("http://localhost:5000/api/v1/sequence")
         mapping = await st.json()
         logging.debug("mapping %s", mapping)
 
@@ -371,7 +371,7 @@ async def test_dump_bin_parameters(
     context = zmq.asyncio.Context()
 
     async with aiohttp.ClientSession() as session:
-        st = await session.get("http://localhost:5000/api/v1/mapping")
+        st = await session.get("http://localhost:5000/api/v1/sequence")
         mapping = await st.json()
         logging.debug("mapping %s", mapping)
 

--- a/tests/test_dumping.py
+++ b/tests/test_dumping.py
@@ -27,7 +27,12 @@ from dranspose.protocol import (
 )
 
 from dranspose.worker import Worker
-from tests.utils import wait_for_controller, wait_for_finish
+from tests.utils import (
+    wait_for_controller,
+    wait_for_finish,
+    set_uniform_sequence,
+    monopart_sequence,
+)
 
 
 @pytest.mark.skipif("config.getoption('rust')", reason="rust does not support dumping")
@@ -97,7 +102,8 @@ async def test_dump(
     )
     async with aiohttp.ClientSession() as session:
         p_prefix = tmp_path / "dump_"
-        logging.info("prefix is %s encoded: %s", p_prefix, str(p_prefix).encode("utf8"))
+        logging.info("prefix is %s encoded: %s", p_prefix,
+                     str(p_prefix).encode("utf8"))
 
         resp = await session.post(
             "http://localhost:5000/api/v1/parameter/dump_prefix",
@@ -106,9 +112,7 @@ async def test_dump(
         assert resp.status == 200
 
         ntrig = 10
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
+        payload = monopart_sequence({
                 "eiger": [
                     [
                         VirtualWorker(constraint=VirtualConstraint(2 * i)).model_dump(
@@ -149,7 +153,10 @@ async def test_dump(
                     else None
                     for i in range(1, ntrig)
                 ],
-            },
+        })
+        resp = await session.post(
+            "http://localhost:5000/api/v1/sequence",
+            json=payload
         )
         assert resp.status == 200
         uuid = await resp.json()
@@ -229,7 +236,8 @@ async def test_dump_xrd(
     await wait_for_controller(streams={StreamName("xrd")})
     async with aiohttp.ClientSession() as session:
         p_prefix = tmp_path / "dump_"
-        logging.info("prefix is %s encoded: %s", p_prefix, str(p_prefix).encode("utf8"))
+        logging.info("prefix is %s encoded: %s", p_prefix,
+                     str(p_prefix).encode("utf8"))
 
         resp = await session.post(
             "http://localhost:5000/api/v1/parameter/dump_prefix",
@@ -237,21 +245,8 @@ async def test_dump_xrd(
         )
         assert resp.status == 200
 
-        ntrig = 10
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
-                "xrd": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(2 * i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(1, ntrig)
-                ],
-            },
-        )
-        assert resp.status == 200
+    ntrig = 10
+    await set_uniform_sequence({StreamName("xrd")}, ntrig)
 
     context = zmq.asyncio.Context()
 
@@ -293,7 +288,8 @@ async def test_dump_map_and_parameters(
     await wait_for_controller(streams={StreamName("xrd")})
     async with aiohttp.ClientSession() as session:
         p_prefix = tmp_path / "dump_"
-        logging.info("prefix is %s encoded: %s", p_prefix, str(p_prefix).encode("utf8"))
+        logging.info("prefix is %s encoded: %s", p_prefix,
+                     str(p_prefix).encode("utf8"))
 
         pars = {
             "dump_prefix": str(p_prefix).encode("utf8"),
@@ -307,23 +303,8 @@ async def test_dump_map_and_parameters(
             )
             assert resp.status == 200
 
-        ntrig = 10
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
-                "xrd": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(2 * i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(1, ntrig)
-                ],
-            },
-        )
-        assert resp.status == 200
-        uuid = await resp.json()
-
+    ntrig = 10
+    uuid = await set_uniform_sequence({StreamName("xrd")}, ntrig)
     context = zmq.asyncio.Context()
 
     async with aiohttp.ClientSession() as session:
@@ -384,22 +365,8 @@ async def test_dump_bin_parameters(
             )
             assert resp.status == 200
 
-        ntrig = 10
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
-                "xrd": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(2 * i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(1, ntrig)
-                ],
-            },
-        )
-        assert resp.status == 200
-        uuid = await resp.json()
+    ntrig = 10
+    uuid = await set_uniform_sequence({StreamName("xrd")}, ntrig)
 
     context = zmq.asyncio.Context()
 
@@ -424,6 +391,7 @@ async def test_dump_bin_parameters(
         assert pars_dict["test_null"] == pars["test_null"]
 
     context.destroy()
+
 
 @pytest.mark.skipif("config.getoption('rust')", reason="rust does not support dumping")
 @pytest.mark.asyncio
@@ -452,20 +420,12 @@ async def test_dump_and_not_dump(
 
     # Create mapping
     ntrig = 10
-    mapping = {
-            "xrd": [
-                [ VirtualWorker(constraint=VirtualConstraint(2 * i)).model_dump(mode="json") ]
-                for i in range(1, ntrig)
-            ],
-        }
     await wait_for_controller(streams={StreamName("xrd")})
 
     context = zmq.asyncio.Context()
 
     # Run first scan
-    async with aiohttp.ClientSession() as session:
-        resp = await session.post("http://localhost:5000/api/v1/mapping", json=mapping)
-        assert resp.status == 200
+    await set_uniform_sequence({StreamName("xrd")}, ntrig)
     asyncio.create_task(stream_small_xrd(context, 9999, ntrig - 1))
     await wait_for_finish()
 
@@ -473,9 +433,7 @@ async def test_dump_and_not_dump(
     time_between_scans = datetime.now(timezone.utc)
 
     # Run second scan
-    async with aiohttp.ClientSession() as session:
-        resp = await session.post("http://localhost:5000/api/v1/mapping", json=mapping)
-        assert resp.status == 200
+    await set_uniform_sequence({StreamName("xrd")}, ntrig)
     asyncio.create_task(stream_small_xrd(context, 9999, ntrig - 1))
     await wait_for_finish()
 

--- a/tests/test_eiger_legacy.py
+++ b/tests/test_eiger_legacy.py
@@ -3,7 +3,6 @@ import os
 from pathlib import PosixPath
 from typing import Awaitable, Callable, Coroutine, Optional, Any
 
-import aiohttp
 import zmq.asyncio
 
 import pytest
@@ -17,8 +16,6 @@ from dranspose.ingesters.zmqpull_eiger_legacy import (
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 
 from dranspose.worker import Worker, WorkerSettings

--- a/tests/test_eiger_legacy.py
+++ b/tests/test_eiger_legacy.py
@@ -22,7 +22,7 @@ from dranspose.protocol import (
 )
 
 from dranspose.worker import Worker, WorkerSettings
-from tests.utils import wait_for_controller, wait_for_finish
+from tests.utils import wait_for_controller, wait_for_finish, set_uniform_sequence
 
 
 @pytest.mark.asyncio
@@ -55,37 +55,18 @@ async def test_eiger_legacy(
     )
 
     await wait_for_controller(streams={StreamName("eiger")})
-    async with aiohttp.ClientSession() as session:
-        ntrig = 3
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
-                "eiger": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(1, ntrig)
-                ],
-            },
+    ntrig = 3
+    await set_uniform_sequence({StreamName("eiger")}, ntrig)
+    with zmq.asyncio.Context() as context:
+        asyncio.create_task(
+            stream_cbors(
+                context,
+                22005,
+                PosixPath("tests/data/eiger-small.cbors"),
+                0.001,
+                zmq.PUSH,
+                begin=0,  # type: ignore[call-arg]
+            )
         )
-        assert resp.status == 200
-        await resp.json()
-
-    context = zmq.asyncio.Context()
-
-    asyncio.create_task(
-        stream_cbors(
-            context,
-            22005,
-            PosixPath("tests/data/eiger-small.cbors"),
-            0.001,
-            zmq.PUSH,
-            begin=0,  # type: ignore[call-arg]
-        )
-    )
-
-    content = await wait_for_finish()
-
+        content = await wait_for_finish()
     print(content)

--- a/tests/test_empty_event.py
+++ b/tests/test_empty_event.py
@@ -21,6 +21,7 @@ from dranspose.protocol import (
 from dranspose.worker import Worker
 from tests.utils import wait_for_controller, wait_for_finish, vworker, monopart_sequence
 
+
 @pytest.mark.asyncio
 async def test_simple(
     controller: None,
@@ -45,11 +46,13 @@ async def test_simple(
         ntrig = 10
         resp = await session.post(
             "http://localhost:5000/api/v1/sequence",
-            json=monopart_sequence({
-                "eiger": [[vworker(i)] for i in range(1, ntrig - 5)]
-                + [None]
-                + [[vworker(i)] for i in range(ntrig - 5, ntrig)],
-            }),
+            json=monopart_sequence(
+                {
+                    "eiger": [[vworker(i)] for i in range(1, ntrig - 5)]
+                    + [None]
+                    + [[vworker(i)] for i in range(ntrig - 5, ntrig)],
+                }
+            ),
         )
         assert resp.status == 200
 

--- a/tests/test_empty_parameters.py
+++ b/tests/test_empty_parameters.py
@@ -19,8 +19,6 @@ from dranspose.parameters import ParameterList
 from dranspose.protocol import (
     WorkerName,
     StreamName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 from dranspose.worker import Worker, WorkerSettings
 from tests.utils import wait_for_controller, set_uniform_sequence

--- a/tests/test_empty_parameters.py
+++ b/tests/test_empty_parameters.py
@@ -23,7 +23,7 @@ from dranspose.protocol import (
     VirtualConstraint,
 )
 from dranspose.worker import Worker, WorkerSettings
-from tests.utils import wait_for_controller
+from tests.utils import wait_for_controller, set_uniform_sequence
 
 
 @pytest.mark.asyncio
@@ -83,20 +83,7 @@ async def test_empty_params(
         logging.warning("params %s", params)
 
         ntrig = 10
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
-                "eiger": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(1, ntrig)
-                ],
-            },
-        )
-        assert resp.status == 200
+        await set_uniform_sequence({StreamName("eiger")}, ntrig)
 
         context = zmq.asyncio.Context()
 

--- a/tests/test_ingest_stats.py
+++ b/tests/test_ingest_stats.py
@@ -17,8 +17,6 @@ from dranspose.ingesters.zmqpull_single import (
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
     EnsembleState,
 )
 
@@ -81,4 +79,3 @@ async def test_map(
             logging.info("state is \n%s", "\n".join(msg))
 
     print(content)
-

--- a/tests/test_ingest_stats.py
+++ b/tests/test_ingest_stats.py
@@ -23,7 +23,7 @@ from dranspose.protocol import (
 )
 
 from dranspose.worker import Worker
-from tests.utils import wait_for_controller, wait_for_finish
+from tests.utils import wait_for_controller, wait_for_finish, set_uniform_sequence
 
 
 @pytest.mark.asyncio
@@ -58,45 +58,27 @@ async def test_map(
     )
 
     await wait_for_controller(streams={StreamName("eiger"), StreamName("orca")})
-    async with aiohttp.ClientSession() as session:
-        ntrig = 100
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
-                "eiger": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(1, ntrig)
-                ],
-                # no frames to orca
-            },
-        )
-        assert resp.status == 200
+    ntrig = 100
+    await set_uniform_sequence({StreamName("eiger")}, ntrig)
 
-    context = zmq.asyncio.Context()
+    with zmq.asyncio.Context() as context:
+        asyncio.create_task(stream_eiger(context, 9999, ntrig - 1))
+        content = await wait_for_finish()
+        async with aiohttp.ClientSession() as session:
+            st = await session.get("http://localhost:5000/api/v1/config")
+            conf = EnsembleState.model_validate(await st.json())
+            msg = []
 
-    asyncio.create_task(stream_eiger(context, 9999, ntrig - 1))
+            for k in conf.workers + conf.ingesters + [conf.reducer]:
+                if k is None:
+                    continue
+                msg.append(f"{k.name}:{k.processed_events} -- {k.event_rate}")
+                if k.name == "eiger-ingester":
+                    assert k.processed_events > 0
+                elif k.name == "orca-ingester":
+                    assert k.processed_events == 0
 
-    content = await wait_for_finish()
-    async with aiohttp.ClientSession() as session:
-        st = await session.get("http://localhost:5000/api/v1/config")
-        conf = EnsembleState.model_validate(await st.json())
-        msg = []
-
-        for k in conf.workers + conf.ingesters + [conf.reducer]:
-            if k is None:
-                continue
-            msg.append(f"{k.name}:{k.processed_events} -- {k.event_rate}")
-            if k.name == "eiger-ingester":
-                assert k.processed_events > 0
-            elif k.name == "orca-ingester":
-                assert k.processed_events == 0
-
-        logging.info("state is \n%s", "\n".join(msg))
-
-    context.destroy()
+            logging.info("state is \n%s", "\n".join(msg))
 
     print(content)
+

--- a/tests/test_leave_pcap_alone.py
+++ b/tests/test_leave_pcap_alone.py
@@ -3,7 +3,6 @@ import logging
 from asyncio import StreamReader, StreamWriter
 from typing import Awaitable, Callable, Coroutine, Optional, Any
 
-import aiohttp
 
 import pytest
 import zmq
@@ -19,8 +18,6 @@ from dranspose.ingesters.tcp_positioncap import TcpPcapIngester, TcpPcapSettings
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 
 from dranspose.worker import Worker, WorkerSettings

--- a/tests/test_lecroy.py
+++ b/tests/test_lecroy.py
@@ -16,9 +16,7 @@ from dranspose.ingesters.zmqsub_lecroy import ZmqSubLecroyIngester, ZmqSubLecroy
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
     ParameterName,
-    VirtualConstraint,
 )
 
 from dranspose.worker import Worker, WorkerSettings
@@ -82,7 +80,6 @@ async def test_lecroy(
         streams={StreamName("lecroy")}, parameters={ParameterName("channel")}
     )
     await set_uniform_sequence({StreamName("lecroy")}, ntrig)
-
 
     context = zmq.asyncio.Context()
 

--- a/tests/test_lecroy.py
+++ b/tests/test_lecroy.py
@@ -22,7 +22,7 @@ from dranspose.protocol import (
 )
 
 from dranspose.worker import Worker, WorkerSettings
-from tests.utils import wait_for_controller
+from tests.utils import wait_for_controller, set_uniform_sequence
 
 
 @pytest.mark.parametrize(
@@ -81,20 +81,8 @@ async def test_lecroy(
     await wait_for_controller(
         streams={StreamName("lecroy")}, parameters={ParameterName("channel")}
     )
-    async with aiohttp.ClientSession() as session:
-        map = {
-            "lecroy": [
-                [VirtualWorker(constraint=VirtualConstraint(i)).model_dump(mode="json")]
-                for i in range(1, ntrig)
-            ],
-        }
-        logging.debug(f"Sending {map=}")
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json=map,
-        )
-        assert resp.status == 200
-        await resp.json()
+    await set_uniform_sequence({StreamName("lecroy")}, ntrig)
+
 
     context = zmq.asyncio.Context()
 

--- a/tests/test_mapping_sequence.py
+++ b/tests/test_mapping_sequence.py
@@ -81,7 +81,7 @@ async def test_sequence(
 
     await wait_for_finish()
     async with aiohttp.ClientSession() as session:
-        st = await session.get("http://localhost:5000/api/v1/mapping")
+        st = await session.get("http://localhost:5000/api/v1/sequence")
         content = await st.json()
         assert content == {
             "parts": {

--- a/tests/test_maxrate.py
+++ b/tests/test_maxrate.py
@@ -58,7 +58,9 @@ async def test_simple(
     await wait_for_controller(streams={StreamName("eiger")})
     async with aiohttp.ClientSession() as session:
         ntrig = 100
-        mapping = monopart_sequence({ "eiger": [[vworker(i // 10)] for i in range(1, ntrig)] })
+        mapping = monopart_sequence(
+            {"eiger": [[vworker(i // 10)] for i in range(1, ntrig)]}
+        )
         resp = await session.post(
             "http://localhost:5000/api/v1/sequence",
             json=mapping,

--- a/tests/test_mulitple_scans.py
+++ b/tests/test_mulitple_scans.py
@@ -26,7 +26,7 @@ from dranspose.protocol import (
     VirtualConstraint,
 )
 from dranspose.worker import Worker, WorkerSettings
-from tests.utils import wait_for_controller, wait_for_finish
+from tests.utils import wait_for_controller, wait_for_finish, set_uniform_sequence
 
 
 @pytest.mark.asyncio
@@ -76,24 +76,8 @@ async def test_multiple_scans(
         )
         assert resp.status == 200
         await resp.json()
-
-        ntrig = 20
-        mp = {
-            "contrast": [
-                [VirtualWorker(constraint=VirtualConstraint(i)).model_dump(mode="json")]
-                for i in range(ntrig)
-            ],
-            "xspress3": [
-                [VirtualWorker(constraint=VirtualConstraint(i)).model_dump(mode="json")]
-                for i in range(ntrig)
-            ],
-        }
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json=mp,
-        )
-        assert resp.status == 200
-        await resp.json()
+    ntrig = 20
+    await set_uniform_sequence({StreamName("contrast"), StreamName("xspress3")}, ntrig)
 
     context = zmq.asyncio.Context()
 
@@ -159,13 +143,7 @@ async def test_multiple_scans(
         )
 
     # second scan
-    async with aiohttp.ClientSession() as session:
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json=mp,
-        )
-        assert resp.status == 200
-        await resp.json()
+    await set_uniform_sequence({StreamName("contrast"), StreamName("xspress3")}, ntrig)
 
     await stream_cbors(
         context,

--- a/tests/test_mulitple_scans.py
+++ b/tests/test_mulitple_scans.py
@@ -22,8 +22,6 @@ from dranspose.ingesters.zmqsub_xspress3 import (
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 from dranspose.worker import Worker, WorkerSettings
 from tests.utils import wait_for_controller, wait_for_finish, set_uniform_sequence

--- a/tests/test_multi_arm_scan.py
+++ b/tests/test_multi_arm_scan.py
@@ -21,8 +21,6 @@ from dranspose.ingesters.tcp_positioncap import (
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 from dranspose.worker import Worker
 from tests.utils import wait_for_controller, wait_for_finish, monopart_sequence, vworker

--- a/tests/test_multi_arm_scan.py
+++ b/tests/test_multi_arm_scan.py
@@ -25,7 +25,7 @@ from dranspose.protocol import (
     VirtualConstraint,
 )
 from dranspose.worker import Worker
-from tests.utils import wait_for_controller, wait_for_finish
+from tests.utils import wait_for_controller, wait_for_finish, monopart_sequence, vworker
 
 
 @pytest.mark.asyncio
@@ -61,21 +61,13 @@ async def test_multiple_scans(
     async with aiohttp.ClientSession() as session:
         ntrig = 20
         mp = {
-            "eiger": [
-                [VirtualWorker(constraint=VirtualConstraint(i)).model_dump(mode="json")]
-                if i % 12 < 10
-                else None
-                for i in range(ntrig)
-            ],
-            "pcap": [
-                [VirtualWorker(constraint=VirtualConstraint(i)).model_dump(mode="json")]
-                for i in range(ntrig)
-            ],
+            "eiger": [[vworker(i)] if i % 12 < 10 else None for i in range(ntrig)],
+            "pcap": [[vworker(i)] for i in range(ntrig)],
         }
         logging.info("map is %s", mp)
         resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json=mp,
+            "http://localhost:5000/api/v1/sequence",
+            json=monopart_sequence(mp),
         )
         assert resp.status == 200
         await resp.json()

--- a/tests/test_outside_scan_push.py
+++ b/tests/test_outside_scan_push.py
@@ -59,17 +59,19 @@ async def test_outside(
         ntrig = 10
         resp = await session.post(
             "http://localhost:5000/api/v1/sequence",
-            json=monopart_sequence({
-                "eiger": [
-                    [
-                        VirtualWorker(
-                            constraint=VirtualConstraint(2 * i),
-                            tags={WorkerTag("debug")},
-                        ).model_dump(mode="json")
-                    ]
-                    for i in range(1, ntrig)
-                ],
-            })
+            json=monopart_sequence(
+                {
+                    "eiger": [
+                        [
+                            VirtualWorker(
+                                constraint=VirtualConstraint(2 * i),
+                                tags={WorkerTag("debug")},
+                            ).model_dump(mode="json")
+                        ]
+                        for i in range(1, ntrig)
+                    ],
+                }
+            ),
         )
         assert resp.status == 200
 

--- a/tests/test_outside_scan_push.py
+++ b/tests/test_outside_scan_push.py
@@ -26,7 +26,7 @@ from dranspose.protocol import (
 )
 
 from dranspose.worker import Worker
-from tests.utils import wait_for_controller, wait_for_finish
+from tests.utils import wait_for_controller, wait_for_finish, monopart_sequence
 
 
 @pytest.mark.asyncio
@@ -58,8 +58,8 @@ async def test_outside(
         await time_beacon(context, 9999, 5, flags=zmq.NOBLOCK)  # type: ignore[call-arg]
         ntrig = 10
         resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
+            "http://localhost:5000/api/v1/sequence",
+            json=monopart_sequence({
                 "eiger": [
                     [
                         VirtualWorker(
@@ -69,7 +69,7 @@ async def test_outside(
                     ]
                     for i in range(1, ntrig)
                 ],
-            },
+            })
         )
         assert resp.status == 200
 

--- a/tests/test_panda.py
+++ b/tests/test_panda.py
@@ -16,7 +16,11 @@ from dranspose.protocol import (
 )
 
 from dranspose.worker import Worker, WorkerSettings
-from tests.utils import wait_for_finish, wait_for_controller
+from tests.utils import (
+    wait_for_finish,
+    wait_for_controller,
+    set_uniform_sequence,
+)
 
 
 @pytest.mark.asyncio
@@ -66,26 +70,8 @@ async def test_pcapingester(
     )
 
     await wait_for_controller(streams={StreamName("pcap")})
-    async with aiohttp.ClientSession() as session:
-        ntrig = 10
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
-                "pcap": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(2 * i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(1, ntrig)
-                ],
-            },
-        )
-        assert resp.status == 200
-        await resp.json()
-
+    ntrig = 10
+    await set_uniform_sequence({StreamName("pcap")}, ntrig)
     asyncio.create_task(stream_pcap(ntrig - 1))
-
     content = await wait_for_finish()
-
     print(content)

--- a/tests/test_panda.py
+++ b/tests/test_panda.py
@@ -1,7 +1,6 @@
 import asyncio
 from typing import Awaitable, Callable, Coroutine, Optional
 
-import aiohttp
 
 import pytest
 from pydantic_core import Url
@@ -11,8 +10,6 @@ from dranspose.ingesters.tcp_positioncap import TcpPcapIngester, TcpPcapSettings
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 
 from dranspose.worker import Worker, WorkerSettings

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -21,8 +21,6 @@ from dranspose.parameters import ParameterList
 from dranspose.protocol import (
     WorkerName,
     StreamName,
-    VirtualWorker,
-    VirtualConstraint,
     EnsembleState,
 )
 from dranspose.worker import Worker, WorkerSettings

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -26,7 +26,7 @@ from dranspose.protocol import (
     EnsembleState,
 )
 from dranspose.worker import Worker, WorkerSettings
-from tests.utils import wait_for_controller
+from tests.utils import wait_for_controller, set_uniform_sequence
 
 
 @pytest.mark.asyncio
@@ -137,17 +137,7 @@ async def test_params(
             logging.warning("got state %s", state)
 
         ntrig = 20
-        mp = {
-            "contrast": [
-                [VirtualWorker(constraint=VirtualConstraint(i)).model_dump(mode="json")]
-                for i in range(ntrig)
-            ],
-        }
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json=mp,
-        )
-        assert resp.status == 200
+        await set_uniform_sequence({StreamName("contrast")}, ntrig)
 
         context = zmq.asyncio.Context()
 

--- a/tests/test_pcap_zmq.py
+++ b/tests/test_pcap_zmq.py
@@ -3,7 +3,6 @@ import os
 from pathlib import PosixPath
 from typing import Awaitable, Callable, Coroutine, Optional, Any
 
-import aiohttp
 import zmq.asyncio
 
 import pytest
@@ -14,8 +13,6 @@ from dranspose.ingesters.zmqsub_pcap import ZmqSubPCAPIngester, ZmqSubPCAPSettin
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 
 from dranspose.worker import Worker, WorkerSettings

--- a/tests/test_processingtime.py
+++ b/tests/test_processingtime.py
@@ -7,8 +7,6 @@ from dranspose.protocol import (
     StreamName,
     WorkerName,
     WorkerTimes,
-    VirtualWorker,
-    VirtualConstraint,
     EventNumber,
     SystemLoadType,
 )
@@ -97,7 +95,6 @@ async def test_simple(
     with zmq.asyncio.Context() as context:
         asyncio.create_task(stream_eiger(context, 9999, ntrig - 1, 0.1))
         await wait_for_finish()
-
 
     async with aiohttp.ClientSession() as session:
         st = await session.get("http://localhost:5000/api/v1/status")

--- a/tests/test_processingtime.py
+++ b/tests/test_processingtime.py
@@ -25,7 +25,7 @@ import zmq
 from pydantic_core import Url
 
 from dranspose.worker import Worker, WorkerSettings
-from tests.utils import wait_for_controller, wait_for_finish
+from tests.utils import wait_for_controller, wait_for_finish, set_uniform_sequence
 
 
 @pytest.mark.asyncio
@@ -91,30 +91,13 @@ async def test_simple(
         load = await st.json()
         assert load == {}
 
-        ntrig = 100
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
-                "eiger": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(2 * i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(1, ntrig)
-                ],
-            },
-        )
-        assert resp.status == 200
-        await resp.json()
+    ntrig = 100
+    await set_uniform_sequence({StreamName("eiger")}, ntrig)
 
-    context = zmq.asyncio.Context()
+    with zmq.asyncio.Context() as context:
+        asyncio.create_task(stream_eiger(context, 9999, ntrig - 1, 0.1))
+        await wait_for_finish()
 
-    asyncio.create_task(stream_eiger(context, 9999, ntrig - 1, 0.1))
-
-    await wait_for_finish()
-
-    context.destroy()
 
     async with aiohttp.ClientSession() as session:
         st = await session.get("http://localhost:5000/api/v1/status")

--- a/tests/test_reducer.py
+++ b/tests/test_reducer.py
@@ -29,7 +29,7 @@ from dranspose.protocol import (
     VirtualConstraint,
 )
 from dranspose.worker import Worker, WorkerSettings
-from tests.utils import wait_for_finish, wait_for_controller
+from tests.utils import wait_for_finish, wait_for_controller, set_uniform_sequence
 
 
 @pytest.mark.asyncio
@@ -86,30 +86,9 @@ async def test_reduction(
         assert resp.status == 200
         await resp.json()
 
-        ntrig = 20
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
-                "contrast": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(ntrig)
-                ],
-                "xspress3": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(ntrig)
-                ],
-            },
-        )
-        assert resp.status == 200
-        await resp.json()
+    ntrig = 20
+    await set_uniform_sequence({StreamName("contrast"), StreamName("xspress3")}, ntrig+1)
+    #                                                 +1 because we do range(1,ntrig) ^
 
     context = zmq.asyncio.Context()
 

--- a/tests/test_reducer.py
+++ b/tests/test_reducer.py
@@ -25,8 +25,6 @@ from dranspose.ingesters.zmqsub_xspress3 import (
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 from dranspose.worker import Worker, WorkerSettings
 from tests.utils import wait_for_finish, wait_for_controller, set_uniform_sequence
@@ -87,7 +85,9 @@ async def test_reduction(
         await resp.json()
 
     ntrig = 20
-    await set_uniform_sequence({StreamName("contrast"), StreamName("xspress3")}, ntrig+1)
+    await set_uniform_sequence(
+        {StreamName("contrast"), StreamName("xspress3")}, ntrig + 1
+    )
     #                                                 +1 because we do range(1,ntrig) ^
 
     context = zmq.asyncio.Context()

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -26,8 +26,6 @@ from dranspose.ingesters.zmqpull_single import (
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 
 from dranspose.replay import replay
@@ -110,17 +108,19 @@ async def dump_data(
         ntrig = 10
         resp = await session.post(
             "http://localhost:5000/api/v1/sequence",
-            json=monopart_sequence({
-                "eiger": [ [ vworker(2 * i) ] for i in range(1, ntrig) ],
-                "orca": [ [ vworker(2 * i + 1) ] for i in range(1, ntrig) ],
-                "alba": [ [ vworker(2 * i), vworker(2 * i + 1) ] for i in range(1, ntrig) ],
-                "slow": [
-                    [ vworker(2 * i), vworker(2 * i + 1) ]
-                    if i % 4 == 0
-                    else None
-                    for i in range(1, ntrig)
-                ],
-            }),
+            json=monopart_sequence(
+                {
+                    "eiger": [[vworker(2 * i)] for i in range(1, ntrig)],
+                    "orca": [[vworker(2 * i + 1)] for i in range(1, ntrig)],
+                    "alba": [
+                        [vworker(2 * i), vworker(2 * i + 1)] for i in range(1, ntrig)
+                    ],
+                    "slow": [
+                        [vworker(2 * i), vworker(2 * i + 1)] if i % 4 == 0 else None
+                        for i in range(1, ntrig)
+                    ],
+                }
+            ),
         )
         assert resp.status == 200
         uuid = await resp.json()

--- a/tests/test_repub.py
+++ b/tests/test_repub.py
@@ -5,15 +5,12 @@ from typing import Awaitable, Callable, Any, Coroutine, Optional
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 from dranspose.ingester import Ingester
 from dranspose.ingesters.zmqpull_single import (
     ZmqPullSingleIngester,
     ZmqPullSingleSettings,
 )
-import aiohttp
 
 import pytest
 import zmq.asyncio

--- a/tests/test_restart_ingester.py
+++ b/tests/test_restart_ingester.py
@@ -1,7 +1,6 @@
 import asyncio
 from typing import Awaitable, Callable, Any, Coroutine, Optional
 
-import aiohttp
 
 import pytest
 import zmq.asyncio
@@ -16,8 +15,6 @@ from dranspose.ingesters.zmqpull_single import (
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 
 from dranspose.worker import Worker

--- a/tests/test_restart_worker.py
+++ b/tests/test_restart_worker.py
@@ -16,8 +16,6 @@ from dranspose.ingesters.zmqpull_single import (
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
     EnsembleState,
 )
 

--- a/tests/test_restart_worker.py
+++ b/tests/test_restart_worker.py
@@ -22,7 +22,7 @@ from dranspose.protocol import (
 )
 
 from dranspose.worker import Worker
-from tests.utils import wait_for_controller, wait_for_finish
+from tests.utils import wait_for_controller, wait_for_finish, set_uniform_sequence
 
 
 @pytest.mark.asyncio
@@ -45,23 +45,8 @@ async def test_restart_worker(
     )
 
     await wait_for_controller(streams={StreamName("eiger")})
-    async with aiohttp.ClientSession() as session:
-        ntrig = 10
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
-                "eiger": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(2 * i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(1, ntrig)
-                ],
-            },
-        )
-        assert resp.status == 200
-
+    ntrig = 10
+    await set_uniform_sequence({StreamName("eiger")}, ntrig)
     context = zmq.asyncio.Context()
 
     asyncio.create_task(stream_eiger(context, 9999, ntrig - 1))

--- a/tests/test_round_robin.py
+++ b/tests/test_round_robin.py
@@ -5,8 +5,6 @@ from typing import Awaitable, Callable, Any, Coroutine, Optional
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 from dranspose.ingester import Ingester
 from dranspose.ingesters.zmqpull_single import (
@@ -90,8 +88,12 @@ async def test_roundrobin(
     await wait_for_controller(streams={StreamName("eiger")})
     async with aiohttp.ClientSession() as session:
         ntrig = 10
-        sequence = monopart_sequence({ "eiger": [[vworker(i % 3)] for i in range(1, ntrig)] })
-        resp = await session.post("http://localhost:5000/api/v1/sequence", json=sequence)
+        sequence = monopart_sequence(
+            {"eiger": [[vworker(i % 3)] for i in range(1, ntrig)]}
+        )
+        resp = await session.post(
+            "http://localhost:5000/api/v1/sequence", json=sequence
+        )
         assert resp.status == 200
         await resp.json()
 

--- a/tests/test_round_robin.py
+++ b/tests/test_round_robin.py
@@ -21,7 +21,7 @@ import zmq
 from pydantic_core import Url
 
 from dranspose.worker import Worker, WorkerSettings
-from tests.utils import wait_for_finish, wait_for_controller
+from tests.utils import wait_for_finish, wait_for_controller, vworker, monopart_sequence
 
 
 async def consume_round_robin(ctx: zmq.Context[Any], ports: list[int], num: int) -> int:
@@ -90,32 +90,15 @@ async def test_roundrobin(
     await wait_for_controller(streams={StreamName("eiger")})
     async with aiohttp.ClientSession() as session:
         ntrig = 10
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
-                "eiger": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(i % 3)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(1, ntrig)
-                ],
-            },
-        )
+        sequence = monopart_sequence({ "eiger": [[vworker(i % 3)] for i in range(1, ntrig)] })
+        resp = await session.post("http://localhost:5000/api/v1/sequence", json=sequence)
         assert resp.status == 200
         await resp.json()
 
-    context = zmq.asyncio.Context()
-
-    collector = asyncio.create_task(
-        consume_round_robin(context, [5556, 5557, 5558], ntrig - 1 + 2 * 3)
-    )
-
-    asyncio.create_task(stream_eiger(context, 9999, ntrig - 1, 0.1))
-
-    await wait_for_finish()
-
-    await collector
-
-    context.destroy()
+    with zmq.asyncio.Context() as context:
+        collector = asyncio.create_task(
+            consume_round_robin(context, [5556, 5557, 5558], ntrig - 1 + 2 * 3)
+        )
+        asyncio.create_task(stream_eiger(context, 9999, ntrig - 1, 0.1))
+        await wait_for_finish()
+        await collector

--- a/tests/test_rust_ingest.py
+++ b/tests/test_rust_ingest.py
@@ -44,10 +44,14 @@ async def test_rust_basic(
         logging.info("startup done")
 
         ntrig = 50000
-        sequence = monopart_sequence({
-            "eiger": [ [vworker(i // 10)] for i in range(1, ntrig) ],
-        })
-        resp = await session.post("http://localhost:5000/api/v1/sequence", json=sequence)
+        sequence = monopart_sequence(
+            {
+                "eiger": [[vworker(i // 10)] for i in range(1, ntrig)],
+            }
+        )
+        resp = await session.post(
+            "http://localhost:5000/api/v1/sequence", json=sequence
+        )
         assert resp.status == 200
 
     context = zmq.asyncio.Context()

--- a/tests/test_sardana_hook.py
+++ b/tests/test_sardana_hook.py
@@ -44,7 +44,7 @@ async def test_not_enough_workers(
         assert resp.status == 200
         await resp.json()
 
-        ma = await session.get("http://localhost:5000/api/v1/mapping")
+        ma = await session.get("http://localhost:5000/api/v1/sequence")
         mapping = await ma.json()
         logging.info("map in %s", mapping)
 

--- a/tests/test_sardana_ingester.py
+++ b/tests/test_sardana_ingester.py
@@ -1,7 +1,6 @@
 import asyncio
 from typing import Awaitable, Callable, Any, Coroutine, Optional
 
-import aiohttp
 
 import pytest
 import zmq.asyncio
@@ -12,8 +11,6 @@ from pydantic import HttpUrl
 from dranspose.ingester import Ingester
 from dranspose.protocol import (
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
     StreamName,
 )
 

--- a/tests/test_sardana_ingester.py
+++ b/tests/test_sardana_ingester.py
@@ -20,7 +20,7 @@ from dranspose.protocol import (
 from dranspose.worker import Worker
 
 from dranspose.ingesters.http_sardana import app as custom_app
-from tests.utils import wait_for_controller, wait_for_finish
+from tests.utils import wait_for_controller, wait_for_finish, set_uniform_sequence
 
 
 @pytest.mark.asyncio
@@ -37,22 +37,8 @@ async def test_sardana(
     await http_ingester(custom_app, 5002, {"ingester_streams": ["sardana"]})
 
     await wait_for_controller(streams={StreamName("sardana")})
-    async with aiohttp.ClientSession() as session:
-        ntrig = 10
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
-                "sardana": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(2 * i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(1, ntrig)
-                ],
-            },
-        )
-        assert resp.status == 200
+    ntrig = 10
+    await set_uniform_sequence({StreamName("sardana")}, ntrig)
 
     context = zmq.asyncio.Context()
 

--- a/tests/test_short_scans.py
+++ b/tests/test_short_scans.py
@@ -27,7 +27,7 @@ from dranspose.protocol import (
     VirtualConstraint,
 )
 from dranspose.worker import Worker, WorkerSettings
-from tests.utils import wait_for_controller, wait_for_finish
+from tests.utils import wait_for_controller, wait_for_finish, set_uniform_sequence
 
 
 @pytest.mark.asyncio
@@ -70,6 +70,8 @@ async def test_short_scans(
     )
 
     await wait_for_controller(streams={StreamName("contrast"), StreamName("xspress3")})
+
+    ntrig = 30
     async with aiohttp.ClientSession() as session:
         resp = await session.post(
             "http://localhost:5000/api/v1/parameter/roi1",
@@ -77,24 +79,7 @@ async def test_short_scans(
         )
         assert resp.status == 200
         await resp.json()
-
-        ntrig = 30
-        mp = {
-            "contrast": [
-                [VirtualWorker(constraint=VirtualConstraint(i)).model_dump(mode="json")]
-                for i in range(ntrig)
-            ],
-            "xspress3": [
-                [VirtualWorker(constraint=VirtualConstraint(i)).model_dump(mode="json")]
-                for i in range(ntrig)
-            ],
-        }
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json=mp,
-        )
-        assert resp.status == 200
-        await resp.json()
+    await set_uniform_sequence({StreamName("contrast"), StreamName("xspress3")}, ntrig)
 
     context = zmq.asyncio.Context()
 
@@ -176,23 +161,8 @@ async def test_short_scans(
 
     # second scan
     ntrig = 20
-    mp = {
-        "contrast": [
-            [VirtualWorker(constraint=VirtualConstraint(i)).model_dump(mode="json")]
-            for i in range(ntrig)
-        ],
-        "xspress3": [
-            [VirtualWorker(constraint=VirtualConstraint(i)).model_dump(mode="json")]
-            for i in range(ntrig)
-        ],
-    }
-    async with aiohttp.ClientSession() as session:
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json=mp,
-        )
-        assert resp.status == 200
-        await resp.json()
+
+    await set_uniform_sequence({StreamName("contrast"), StreamName("xspress3")}, ntrig)
 
     await stream_cbors(
         context,

--- a/tests/test_short_scans.py
+++ b/tests/test_short_scans.py
@@ -23,8 +23,6 @@ from dranspose.ingesters.zmqsub_xspress3 import (
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 from dranspose.worker import Worker, WorkerSettings
 from tests.utils import wait_for_controller, wait_for_finish, set_uniform_sequence

--- a/tests/test_slowreduce.py
+++ b/tests/test_slowreduce.py
@@ -21,7 +21,7 @@ import zmq
 from pydantic_core import Url
 
 from dranspose.worker import Worker, WorkerSettings
-from tests.utils import wait_for_finish, wait_for_controller
+from tests.utils import wait_for_finish, wait_for_controller, set_uniform_sequence
 
 
 @pytest.mark.asyncio
@@ -68,30 +68,11 @@ async def test_slowreduce(
         load = await st.json()
         assert load == {}
 
-        ntrig = 4
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
-                "eiger": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(2 * i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(1, ntrig)
-                ],
-            },
-        )
-        assert resp.status == 200
-        await resp.json()
-
-    context = zmq.asyncio.Context()
-
-    asyncio.create_task(stream_eiger(context, 9999, ntrig - 1, 0.1))
-
-    await wait_for_finish()
-
-    context.destroy()
+    ntrig = 4
+    await set_uniform_sequence({StreamName("eiger")}, ntrig)
+    with zmq.asyncio.Context() as context:
+        asyncio.create_task(stream_eiger(context, 9999, ntrig - 1, 0.1))
+        await wait_for_finish()
 
     async with aiohttp.ClientSession() as session:
         st = await session.get("http://localhost:5001/api/v1/result/")

--- a/tests/test_slowreduce.py
+++ b/tests/test_slowreduce.py
@@ -5,8 +5,6 @@ from typing import Awaitable, Callable, Any, Coroutine, Optional
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 from dranspose.ingester import Ingester
 from dranspose.ingesters.zmqpull_single import (

--- a/tests/test_stop_scan.py
+++ b/tests/test_stop_scan.py
@@ -13,8 +13,6 @@ from dranspose.ingesters.zmqpull_single import (
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 from dranspose.worker import Worker
 from tests.utils import wait_for_controller, wait_for_finish, set_uniform_sequence
@@ -42,13 +40,8 @@ async def test_stop_scans(
     ntrig = 30
     await set_uniform_sequence({StreamName("eiger")}, ntrig)
     context = zmq.asyncio.Context()
-
-    # asyncio.create_task()
-
     async with aiohttp.ClientSession() as session:
-        resp = await session.post(
-            "http://localhost:5000/api/v1/stop",
-        )
+        await session.post("http://localhost:5000/api/v1/stop")
 
     await wait_for_finish()
 

--- a/tests/test_stop_scan.py
+++ b/tests/test_stop_scan.py
@@ -17,7 +17,7 @@ from dranspose.protocol import (
     VirtualConstraint,
 )
 from dranspose.worker import Worker
-from tests.utils import wait_for_controller, wait_for_finish
+from tests.utils import wait_for_controller, wait_for_finish, set_uniform_sequence
 
 
 @pytest.mark.asyncio
@@ -39,21 +39,8 @@ async def test_stop_scans(
     )
 
     await wait_for_controller(streams={StreamName("eiger")})
-    async with aiohttp.ClientSession() as session:
-        ntrig = 30
-        mp = {
-            "eiger": [
-                [VirtualWorker(constraint=VirtualConstraint(i)).model_dump(mode="json")]
-                for i in range(ntrig)
-            ],
-        }
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json=mp,
-        )
-        assert resp.status == 200
-        await resp.json()
-
+    ntrig = 30
+    await set_uniform_sequence({StreamName("eiger")}, ntrig)
     context = zmq.asyncio.Context()
 
     # asyncio.create_task()

--- a/tests/test_timestamping.py
+++ b/tests/test_timestamping.py
@@ -6,8 +6,6 @@ from typing import Awaitable, Callable, Any, Coroutine, Optional
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 from dranspose.ingester import Ingester
 from dranspose.ingesters.zmqpull_single import (
@@ -66,7 +64,6 @@ async def test_timestamps(
     with zmq.asyncio.Context() as context:
         asyncio.create_task(stream_eiger(context, 9999, ntrig - 1, 0.1))
         await wait_for_finish()
-
 
     async with aiohttp.ClientSession() as session:
         st = await session.get("http://localhost:5001/api/v1/result/")

--- a/tests/test_timestamping.py
+++ b/tests/test_timestamping.py
@@ -22,7 +22,7 @@ import zmq
 from pydantic_core import Url
 
 from dranspose.worker import Worker, WorkerSettings
-from tests.utils import wait_for_controller, wait_for_finish
+from tests.utils import wait_for_controller, wait_for_finish, set_uniform_sequence
 
 
 @pytest.mark.asyncio
@@ -61,30 +61,12 @@ async def test_timestamps(
         load = await st.json()
         assert load == {}
 
-        ntrig = 4
-        resp = await session.post(
-            "http://localhost:5000/api/v1/mapping",
-            json={
-                "fast": [
-                    [
-                        VirtualWorker(constraint=VirtualConstraint(2 * i)).model_dump(
-                            mode="json"
-                        )
-                    ]
-                    for i in range(1, ntrig)
-                ],
-            },
-        )
-        assert resp.status == 200
-        await resp.json()
+    ntrig = 4
+    await set_uniform_sequence({StreamName("fast")}, ntrig)
+    with zmq.asyncio.Context() as context:
+        asyncio.create_task(stream_eiger(context, 9999, ntrig - 1, 0.1))
+        await wait_for_finish()
 
-    context = zmq.asyncio.Context()
-
-    asyncio.create_task(stream_eiger(context, 9999, ntrig - 1, 0.1))
-
-    await wait_for_finish()
-
-    context.destroy()
 
     async with aiohttp.ClientSession() as session:
         st = await session.get("http://localhost:5001/api/v1/result/")

--- a/tests/test_xspress_multipart.py
+++ b/tests/test_xspress_multipart.py
@@ -6,7 +6,6 @@ import asyncio
 from typing import Awaitable, Callable, Any, Coroutine, Optional
 import zmq.asyncio
 
-import aiohttp
 import pytest
 from pydantic_core import Url
 
@@ -18,8 +17,6 @@ from dranspose.ingesters.zmqsub_xspress3 import (
 from dranspose.protocol import (
     StreamName,
     WorkerName,
-    VirtualWorker,
-    VirtualConstraint,
 )
 from dranspose.worker import Worker, WorkerSettings
 from tests.utils import wait_for_controller, wait_for_finish, set_uniform_sequence

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -108,6 +108,10 @@ def monopart_sequence(mapping: dict[str, Any]) -> dict[str, Any]:
 
 
 def uniform_sequence(streams: set[StreamName], ntrig: int) -> dict[str, Any]:
+    """
+    QUIRK ALERT: note that this actually expects ntrig-1 triggers,
+    since it starts at 1.
+    """
     return monopart_sequence(
         {
             stream_name: [[vworker(i)] for i in range(1, ntrig)]
@@ -129,5 +133,9 @@ async def set_sequence(sequence: dict[Any, Any]) -> str:
 
 
 async def set_uniform_sequence(streams: set[StreamName], ntrig: int) -> str:
+    """
+    QUIRK ALERT: note that this actually expects ntrig-1 triggers,
+    since it starts at 1.
+    """
     sequence = uniform_sequence(streams, ntrig)
     return await set_sequence(sequence)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -93,9 +93,11 @@ async def wait_for_finish(
         return content
 
 
-def vworker(constraint: int, tags: Optional[set[str]] = None) -> dict[str, Any]:
+def vworker(constraint: Optional[int] = None, tags: Optional[set[str]] = None) -> dict[str, Any]:
     """ this is just syntactic sugar to define a virtual worker"""
-    vw = VirtualWorker(constraint=VirtualConstraint(constraint))
+    vw = VirtualWorker()
+    if constraint is not None:
+        vw.constraint = VirtualConstraint(constraint)
     if tags is not None:
         vw.tags = {WorkerTag(t) for t in tags}
     return vw.model_dump(mode="json")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,16 +32,14 @@ async def wait_for_controller(
         state = EnsembleState.model_validate(await st.json())
         timeout = 0
         while not (
-            streams <= set(state.get_streams()) and workers <= set(
-                state.get_workers())
+            streams <= set(state.get_streams()) and workers <= set(state.get_workers())
         ):
             await asyncio.sleep(0.3)
             timeout += 1
             st = await session.get(f"{controller}api/v1/config")
             state = EnsembleState.model_validate(await st.json())
             if timeout < 20:
-                logging.debug(
-                    "queried for components to become available %s", state)
+                logging.debug("queried for components to become available %s", state)
             elif timeout % 4 == 0:
                 logging.warning("still waiting for conponents %s", state)
             elif timeout > 40:
@@ -93,8 +91,10 @@ async def wait_for_finish(
         return content
 
 
-def vworker(constraint: Optional[int] = None, tags: Optional[set[str]] = None) -> dict[str, Any]:
-    """ this is just syntactic sugar to define a virtual worker"""
+def vworker(
+    constraint: Optional[int] = None, tags: Optional[set[str]] = None
+) -> dict[str, Any]:
+    """this is just syntactic sugar to define a virtual worker"""
     vw = VirtualWorker()
     if constraint is not None:
         vw.constraint = VirtualConstraint(constraint)
@@ -102,32 +102,28 @@ def vworker(constraint: Optional[int] = None, tags: Optional[set[str]] = None) -
         vw.tags = {WorkerTag(t) for t in tags}
     return vw.model_dump(mode="json")
 
+
 def monopart_sequence(mapping: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "parts": {
-            "main": mapping
-        },
-        "sequence": ["main"]
-    }
+    return {"parts": {"main": mapping}, "sequence": ["main"]}
 
 
 def uniform_sequence(streams: set[StreamName], ntrig: int) -> dict[str, Any]:
-    return monopart_sequence({
-        stream_name: [[vworker(i)] for i in range(1, ntrig)]
-        for stream_name in streams
-    })
+    return monopart_sequence(
+        {
+            stream_name: [[vworker(i)] for i in range(1, ntrig)]
+            for stream_name in streams
+        }
+    )
 
 
 async def set_sequence(sequence: dict[Any, Any]) -> str:
     async with aiohttp.ClientSession() as session:
         resp = await session.post(
-            "http://localhost:5000/api/v1/sequence/",
-            json=sequence
+            "http://localhost:5000/api/v1/sequence/", json=sequence
         )
         if resp.status != 200:
             print("sent", sequence)
-            raise RuntimeError(
-                f"bad response when setting sequence: {resp.status=}")
+            raise RuntimeError(f"bad response when setting sequence: {resp.status=}")
         uuid = await resp.json()
         return uuid
 


### PR DESCRIPTION
Resolves #12 

This also removes all internal references to /api/v1/mapping

A few helpers are added to remove the amount of copy-pasta in the tests.
Please tell me if it's not totally obvious what the helpers do, and I will add some docstrings :)