### PR TITLE
dump dict to h5 file

### DIFF
--- a/dranspose/helpers/h5dump.py
+++ b/dranspose/helpers/h5dump.py
@@ -1,0 +1,37 @@
+import logging
+from contextlib import nullcontext
+
+import h5py
+
+
+def _dump_dict(obj, grp):
+    if isinstance(obj, dict):
+        for key, val in obj.items():
+            if not isinstance(key, str):
+                logging.warning("unable to use non-string key: %s as group name", key)
+                continue
+            if key.endswith("_attrs"):
+                continue
+            if isinstance(val, dict):
+                new_grp = grp.create_group(key)
+                _dump_dict(val, new_grp)
+            else:
+                try:
+                    grp.create_dataset(key, data=val)
+                except Exception as e:
+                    logging.warning("unable to dump %s: %s", key, e.__repr__())
+        for key, val in obj.items():
+            if key.endswith("_attrs"):
+                if key[:-6] in obj:
+                    for att, attval in val.items():
+                        grp[key[:-6]].attrs[att] = attval
+
+
+def dump(data, filename, lock=None):
+    lock = lock or nullcontext()
+    with lock:
+        group = h5py.File(filename, "w")
+        _dump_dict(data, group)
+        if "_attrs" in data:
+            for att, attval in data["_attrs"].items():
+                group.attrs[att] = attval

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "jsonpath-ng",
     "cbor2",
     "redis-logs",
+    "h5py",
 ]
 dynamic = ["version"]
 

--- a/tests/test_h5dump.py
+++ b/tests/test_h5dump.py
@@ -1,0 +1,46 @@
+from contextlib import nullcontext
+from typing import Any, ContextManager, Tuple
+
+import h5py
+import numpy as np
+import pytest
+from dranspose.helpers.h5dump import dump
+
+
+@pytest.mark.asyncio
+async def test_dump(
+    tmp_path: Any,
+) -> None:
+    def get_data() -> Tuple[dict[str, Any], ContextManager[None]]:
+        dt = np.dtype({"names": ["a", "b"], "formats": [float, int]})
+
+        arr = np.array([(0.5, 1)], dtype=dt)
+
+        data = {
+            "live": 34,
+            "other": {"third": [1, 2, 3]},  # only _attrs allowed in root
+            "other_attrs": {"NX_class": "NXother"},
+            "spaced group": {"space ds": 4, "space ds_attrs": {"bla": 5}},
+            "spaced group_attrs": {"spaced attr": 3},
+            "image": np.ones((1000, 1000)),
+            "specialtyp": np.ones((10, 10), dtype=">u8"),
+            "specialtyp_attrs": {"NXdata": "NXspecial"},
+            "composite": arr,
+            "composite_attrs": {"axes": ["I", "q"]},
+            "nested grp": {"second level": {"third": {"still dict": {"value": 1}}}},
+            "hello": "World",
+            "_attrs": {"NX_class": "NXentry"},
+        }
+        return data, nullcontext()
+
+    dump_file = tmp_path / "test.h5"
+
+    d, lock = get_data()
+    dump(d, dump_file, lock)
+
+    res = h5py.File(dump_file)
+
+    assert res["live"][()] == 34
+    assert res["nested grp/second level/third/still dict/value"][()] == 1
+    assert res["spaced group/space ds"].attrs["bla"] == 5
+    assert res.attrs["NX_class"] == "NXentry"


### PR DESCRIPTION
A simple helper to dump the dict with _attrs to an h5 file without going through the HTTP api for speed.